### PR TITLE
feat(keychain)!: deprecate create methods

### DIFF
--- a/features/keychain/module/__tests__/binauth.test.js
+++ b/features/keychain/module/__tests__/binauth.test.js
@@ -33,4 +33,28 @@ describe('binauth', () => {
     )
     expect(Buffer.compare(signedChallenge, expectedSignedChallenge)).toBe(0)
   })
+
+  it('should create binauth key (using sodium instance)', async () => {
+    const keychain = createKeychain({ seed })
+
+    // Getting the public key to use as identifier
+    const keyId = EXODUS_KEY_IDS.TELEMETRY
+    const { sign: { publicKey } } = await keychain.sodium.getSodiumKeysFromSeed({ keyId })
+
+    const expectedPublicKey = Buffer.from(
+      'eeab6c9e861ed9f3a7f7917f6d972032e3e4d7a433eb6bc30f4b488ee13682c7',
+      'hex'
+    )
+    expect(Buffer.compare(publicKey, expectedPublicKey)).toBe(0)
+
+    // Client signing the challenge
+    const challenge = Buffer.from('aabbccc', 'hex')
+    const signedChallenge = await await keychain.sodium.sign({ keyId, data: challenge })
+
+    const expectedSignedChallenge = Buffer.from(
+      'f87037abf6dd8e46cc691880c008ffa5646ba8bf9f523339a503e16b8f6c92c647e00940804ae64770456e8211c18e27234371e9a5f62505f6f50feafcbb2d0faabbcc',
+      'hex'
+    )
+    expect(Buffer.compare(signedChallenge, expectedSignedChallenge)).toBe(0)
+  })
 })

--- a/features/keychain/module/__tests__/binauth.test.js
+++ b/features/keychain/module/__tests__/binauth.test.js
@@ -39,7 +39,9 @@ describe('binauth', () => {
 
     // Getting the public key to use as identifier
     const keyId = EXODUS_KEY_IDS.TELEMETRY
-    const { sign: { publicKey } } = await keychain.sodium.getSodiumKeysFromSeed({ keyId })
+    const {
+      sign: { publicKey },
+    } = await keychain.sodium.getSodiumKeysFromSeed({ keyId })
 
     const expectedPublicKey = Buffer.from(
       'eeab6c9e861ed9f3a7f7917f6d972032e3e4d7a433eb6bc30f4b488ee13682c7',
@@ -49,7 +51,7 @@ describe('binauth', () => {
 
     // Client signing the challenge
     const challenge = Buffer.from('aabbccc', 'hex')
-    const signedChallenge = await await keychain.sodium.sign({ keyId, data: challenge })
+    const signedChallenge = await keychain.sodium.sign({ keyId, data: challenge })
 
     const expectedSignedChallenge = Buffer.from(
       'f87037abf6dd8e46cc691880c008ffa5646ba8bf9f523339a503e16b8f6c92c647e00940804ae64770456e8211c18e27234371e9a5f62505f6f50feafcbb2d0faabbcc',

--- a/features/keychain/module/__tests__/ecdsa.test.js
+++ b/features/keychain/module/__tests__/ecdsa.test.js
@@ -19,4 +19,14 @@ describe('EcDSA Signer', () => {
       '3045022100e3c37a346dcb717552e9591a43b3f099898cb0a7d2c5aa37447fb0146926bbec022057a2e393efbd154f55278844f402e05c5bedd6a6c205c4b293e50c83813e67a5'
     expect(signature.toString('hex')).toBe(expected)
   })
+
+  it('should signBuffer (using secp256k1 instance)', async () => {
+    const keychain = createKeychain({ seed })
+    const keyId = createKeyIdentifierForExodus({ exoType: 'FUSION' })
+    const plaintext = Buffer.from('I really love keychains')
+    const signature = await keychain.secp256k1.signBuffer({ keyId, data: plaintext })
+    const expected =
+      '3045022100e3c37a346dcb717552e9591a43b3f099898cb0a7d2c5aa37447fb0146926bbec022057a2e393efbd154f55278844f402e05c5bedd6a6c205c4b293e50c83813e67a5'
+    expect(signature.toString('hex')).toBe(expected)
+  })
 })

--- a/features/keychain/module/__tests__/eddsa.test.js
+++ b/features/keychain/module/__tests__/eddsa.test.js
@@ -19,6 +19,17 @@ describe('EdDSA Signer', () => {
     expect(signature.toString('hex')).toBe(expected)
   })
 
+  it('should signBuffer (using ed25519 instance)', async () => {
+    const keychain = createKeychain({ seed })
+    const keyId = createKeyIdentifierForExodus({ exoType: 'FUSION' })
+
+    const plaintext = Buffer.from('I really love keychains')
+    const signature = await keychain.ed25519.signBuffer({ keyId, data: plaintext })
+    const expected =
+      'a929fd6e7e37524320e9f422caef1fefa14d9a70740626116b3570eac7e992893bea708c1b9004e222a779400c7ccabbd344c2399a2e4508f1de1cc602b0590a'
+    expect(signature.toString('hex')).toBe(expected)
+  })
+
   it('should signBuffer', async () => {
     const keychain = createKeychain({ seed })
     const keyId = new KeyIdentifier({
@@ -32,6 +43,23 @@ describe('EdDSA Signer', () => {
       'hex'
     )
     const signature = await signer.signBuffer({ data: plaintext })
+    const expected =
+      '1102815ed29faa093f8365870c892e82ee2aff0e7ded7e337dee4e206613355c786b769cf48269e08ae1646ca70974b4bbfdeb0fd5f459f3ef8b4845b8dd6b0f'
+    expect(signature.toString('hex')).toBe(expected)
+  })
+
+  it('should signBuffer (using ed25519 instance)', async () => {
+    const keychain = createKeychain({ seed })
+    const keyId = new KeyIdentifier({
+      assetName: 'solana',
+      derivationAlgorithm: 'BIP32',
+      derivationPath: "m/44'/501'/0'/0/0",
+    })
+    const plaintext = Buffer.from(
+      '010001030bc08d0b03ca1bc9e72e91084d4f001c5e13270acb4fc2853efe7e6b6560b2d85fc00ab3d38d5424af5b90ea447f1f474a1144be96a6d871ee39587522da7239000000000000000000000000000000000000000000000000000000000000000058c46d1f0395440b25e73ab095b539a5b45c7746dd713131e2cfe2755d03958701020200010c0200000000f2052a01000000',
+      'hex'
+    )
+    const signature = await keychain.ed25519.signBuffer({ keyId, data: plaintext })
     const expected =
       '1102815ed29faa093f8365870c892e82ee2aff0e7ded7e337dee4e206613355c786b769cf48269e08ae1646ca70974b4bbfdeb0fd5f459f3ef8b4845b8dd6b0f'
     expect(signature.toString('hex')).toBe(expected)

--- a/features/keychain/module/__tests__/example.integration-test.js
+++ b/features/keychain/module/__tests__/example.integration-test.js
@@ -165,7 +165,7 @@ test('encryptBox/decryptBox (using sodium instance)', async () => {
   const plaintext = 'I really love keychains'
 
   const {
-    box: { publicKey: bobPublicKey }
+    box: { publicKey: bobPublicKey },
   } = await keychain.sodium.getSodiumKeysFromSeed({ keyId: BOB_KEY })
 
   const ciphertext = await keychain.sodium.encryptBox({
@@ -211,13 +211,13 @@ test('should encryptSealedBox and decryptSealedBox (using sodium instance)', asy
     box: { publicKey: bobPublicKey },
   } = await keychain.sodium.getSodiumKeysFromSeed({ keyId: BOB_KEY })
 
-  const ciphertext = await await keychain.sodium.encryptSealedBox({
+  const ciphertext = await keychain.sodium.encryptSealedBox({
     keyId: ALICE_KEY,
     data: plaintext,
     toPublicKey: bobPublicKey,
   })
 
-  const decrypted = await await keychain.sodium.decryptSealedBox({
+  const decrypted = await keychain.sodium.decryptSealedBox({
     keyId: BOB_KEY,
     data: ciphertext,
   })

--- a/features/keychain/module/__tests__/example.integration-test.js
+++ b/features/keychain/module/__tests__/example.integration-test.js
@@ -254,3 +254,17 @@ test('EdDSA Signer', async () => {
     'd28f13d22ef56c7c5b89a68f67a581ecb01358ed4782dca4f5bc672c4e11d669f853d8110c56dec8bcbafd96bf319d27fa8d8a73dabd95d4c18bf65788a9680d'
   expect(signature.toString('hex')).toBe(expected)
 })
+
+test('EdDSA Signer (using ed25519 instance)', async () => {
+  const keyId = new KeyIdentifier({
+    derivationAlgorithm: 'SLIP10',
+    derivationPath: "m/73'/2'/0'",
+    keyType: 'nacl',
+  })
+
+  const plaintext = Buffer.from('I really love keychains')
+  const signature = await keychain.ed25519.signBuffer({ keyId, data: plaintext })
+  const expected =
+    'd28f13d22ef56c7c5b89a68f67a581ecb01358ed4782dca4f5bc672c4e11d669f853d8110c56dec8bcbafd96bf319d27fa8d8a73dabd95d4c18bf65788a9680d'
+  expect(signature.toString('hex')).toBe(expected)
+})

--- a/features/keychain/module/__tests__/example.integration-test.js
+++ b/features/keychain/module/__tests__/example.integration-test.js
@@ -240,6 +240,20 @@ test('EcDSA Signer', async () => {
   expect(signature.toString('hex')).toBe(expected)
 })
 
+test('EcDSA Signer (using secp256k1 instance)', async () => {
+  const keyId = new KeyIdentifier({
+    derivationAlgorithm: 'SLIP10',
+    derivationPath: "m/73'/2'/0'",
+    keyType: 'nacl',
+  })
+
+  const plaintext = Buffer.from('I really love keychains')
+  const signature = await keychain.secp256k1.signBuffer({ keyId, data: plaintext })
+  const expected =
+    '304402206102dd19cf16e4d88b5bbc07843dae29fb62b13b65207667898363c90b548bf60220577d77bed19009157593f884bfc8a951dbfc9fe4e4fe99ddaed9ab8b558e208c'
+  expect(signature.toString('hex')).toBe(expected)
+})
+
 test('EdDSA Signer', async () => {
   const keyId = new KeyIdentifier({
     derivationAlgorithm: 'SLIP10',

--- a/features/keychain/module/__tests__/example.integration-test.js
+++ b/features/keychain/module/__tests__/example.integration-test.js
@@ -130,6 +130,14 @@ test('encryptSecretBox/decryptSecretBox', async () => {
   expect(decrypted.toString()).toBe(plaintext)
 })
 
+test('encryptSecretBox/decryptSecretBox (using sodium instance)', async () => {
+  const plaintext = 'I really love keychains'
+  const ciphertext = await keychain.sodium.encryptSecretBox({ keyId: ALICE_KEY, data: plaintext })
+  const decrypted = await keychain.sodium.decryptSecretBox({ keyId: ALICE_KEY, data: ciphertext })
+
+  expect(decrypted.toString()).toBe(plaintext)
+})
+
 test('encryptBox/decryptBox', async () => {
   const aliceSodiumEncryptor = await keychain.createSodiumEncryptor(ALICE_KEY)
   const bobSodiumEncryptor = await keychain.createSodiumEncryptor(BOB_KEY)
@@ -153,6 +161,32 @@ test('encryptBox/decryptBox', async () => {
   expect(decrypted.toString()).toBe(plaintext)
 })
 
+test('encryptBox/decryptBox (using sodium instance)', async () => {
+  const plaintext = 'I really love keychains'
+
+  const {
+    box: { publicKey: bobPublicKey }
+  } = await keychain.sodium.getSodiumKeysFromSeed({ keyId: BOB_KEY })
+
+  const ciphertext = await keychain.sodium.encryptBox({
+    keyId: ALICE_KEY,
+    data: plaintext,
+    toPublicKey: bobPublicKey,
+  })
+
+  const {
+    box: { publicKey: alicePublicKey },
+  } = await keychain.sodium.getSodiumKeysFromSeed({ keyId: ALICE_KEY })
+
+  const decrypted = await keychain.sodium.decryptBox({
+    keyId: BOB_KEY,
+    data: ciphertext,
+    fromPublicKey: alicePublicKey,
+  })
+
+  expect(decrypted.toString()).toBe(plaintext)
+})
+
 test('should encryptSealedBox and decryptSealedBox', async () => {
   const aliceSodiumEncryptor = await keychain.createSodiumEncryptor(ALICE_KEY)
   const bobSodiumEncryptor = await keychain.createSodiumEncryptor(BOB_KEY)
@@ -167,6 +201,27 @@ test('should encryptSealedBox and decryptSealedBox', async () => {
   const decrypted = await bobSodiumEncryptor.decryptSealedBox({
     data: ciphertext,
   })
+  expect(decrypted.toString()).toBe(plaintext)
+})
+
+test('should encryptSealedBox and decryptSealedBox (using sodium instance)', async () => {
+  const plaintext = 'I really love keychains'
+
+  const {
+    box: { publicKey: bobPublicKey },
+  } = await keychain.sodium.getSodiumKeysFromSeed({ keyId: BOB_KEY })
+
+  const ciphertext = await await keychain.sodium.encryptSealedBox({
+    keyId: ALICE_KEY,
+    data: plaintext,
+    toPublicKey: bobPublicKey,
+  })
+
+  const decrypted = await await keychain.sodium.decryptSealedBox({
+    keyId: BOB_KEY,
+    data: ciphertext,
+  })
+
   expect(decrypted.toString()).toBe(plaintext)
 })
 

--- a/features/keychain/module/crypto/ed25519.js
+++ b/features/keychain/module/crypto/ed25519.js
@@ -1,11 +1,26 @@
 import sodium from '@exodus/sodium-crypto'
+import { mapValues } from '@exodus/basic-utils'
 
-export const createEd25519Signer = (privateKey) => {
-  const sodiumKeysPromise = sodium.getSodiumKeysFromSeed(privateKey)
-  return Object.freeze({
-    signBuffer: async ({ data }) => {
-      const { sign } = await sodiumKeysPromise
+export const create = ({ getPrivateHDKey }) => {
+  const getSodiumKeysFromIdentifier = async (keyId) => {
+    const { privateKey: sodiumSeed } = getPrivateHDKey(keyId)
+    return sodium.getSodiumKeysFromSeed(sodiumSeed)
+  }
+
+  const createInstance = () => ({
+    signBuffer: async ({ keyId, data }) => {
+      const { sign } = await getSodiumKeysFromIdentifier(keyId)
       return sodium.signDetached({ message: data, privateKey: sign.privateKey })
     },
   })
+
+  // For backwards compatibility
+  // Remove after createEd25519Signer is deprecated
+  const createSigner = ({ keyId }) => {
+    const instance = createInstance()
+    const signer = mapValues(instance, (fn) => async (args) => fn({ ...args, keyId }))
+    return Object.freeze(signer)
+  }
+
+  return Object.freeze({ ...createInstance(), createSigner })
 }

--- a/features/keychain/module/crypto/secp256k1.js
+++ b/features/keychain/module/crypto/secp256k1.js
@@ -1,11 +1,24 @@
 import elliptic from '@exodus/elliptic'
+import { mapValues } from '@exodus/basic-utils'
 
-export const createSecp256k1Signer = (privateKey) => {
+export const create = ({ getPrivateHDKey }) => {
   const EC = elliptic.ec
   const curve = new EC('secp256k1')
-  return Object.freeze({
-    signBuffer: async ({ data }) => {
+
+  const createInstance = () => ({
+    signBuffer: async ({ keyId, data }) => {
+      const { privateKey } = getPrivateHDKey(keyId)
       return Buffer.from(curve.sign(data, privateKey).toDER())
     },
   })
+
+  // For backwards compatibility
+  // Remove after createSecp256k1Signer is deprecated
+  const createSigner = ({ keyId }) => {
+    const instance = createInstance()
+    const signer = mapValues(instance, (fn) => async (args) => fn({ ...args, keyId }))
+    return Object.freeze(signer)
+  }
+
+  return Object.freeze({ ...createInstance(), createSigner })
 }

--- a/features/keychain/module/crypto/sodium.js
+++ b/features/keychain/module/crypto/sodium.js
@@ -1,68 +1,81 @@
 import sodium from '@exodus/sodium-crypto'
+import { mapValues } from '@exodus/basic-utils'
 
-export const createSodiumEncryptor = (sodiumSeed) => {
+const cloneBuffer = (buf) => {
+  const newBuffer = Buffer.alloc(buf.length)
+  buf.copy(newBuffer)
+  return newBuffer
+}
+
+export const create = ({ getPrivateHDKey }) => {
   // Sodium encryptor caches the private key and the return value holds
   // not refences to keychain internals, allowing the seed to be safely
   // garbage collected, clearing it from memory.
-  const sodiumKeysPromise = sodium.getSodiumKeysFromSeed(sodiumSeed)
-  return Object.freeze({
-    getSodiumKeysFromSeed: async () => {
-      const { box, sign, secret } = await sodiumKeysPromise
-      // Do not allow mutation of the original key material.
-      const clone = (buf) => {
-        const newBuffer = Buffer.alloc(buf.length)
-        buf.copy(newBuffer)
-        return newBuffer
-      }
+  const getSodiumKeysFromIdentifier = async (keyId) => {
+    const { privateKey: sodiumSeed } = getPrivateHDKey(keyId)
+    return sodium.getSodiumKeysFromSeed(sodiumSeed)
+  }
+
+  const createInstance = () => ({
+    getSodiumKeysFromSeed: async ({ keyId }) => {
+      const { box, sign, secret } = await getSodiumKeysFromIdentifier(keyId)
 
       return {
-        box: {
-          publicKey: clone(box.publicKey),
-        },
-        sign: {
-          publicKey: clone(sign.publicKey),
-        },
-        secret: clone(secret),
+        box: { publicKey: cloneBuffer(box.publicKey) },
+        sign: { publicKey: cloneBuffer(sign.publicKey) },
+        secret: cloneBuffer(secret),
       }
     },
-    sign: async ({ data }) => {
-      const { sign } = await sodiumKeysPromise
+    sign: async ({ keyId, data }) => {
+      const { sign } = await getSodiumKeysFromIdentifier(keyId)
       return sodium.sign({ message: data, privateKey: sign.privateKey })
     },
-    signOpen: async ({ data }) => {
-      const { sign } = await sodiumKeysPromise
+    signOpen: async ({ keyId, data }) => {
+      const { sign } = await getSodiumKeysFromIdentifier(keyId)
       return sodium.signOpen({ signed: data, publicKey: sign.publicKey })
     },
-    signDetached: async ({ data }) => {
-      const { sign } = await sodiumKeysPromise
+    signDetached: async ({ keyId, data }) => {
+      const { sign } = await getSodiumKeysFromIdentifier(keyId)
       return sodium.signDetached({ message: data, privateKey: sign.privateKey })
     },
-    verifyDetached: async ({ data, signature }) => {
-      const { sign } = await sodiumKeysPromise
+    verifyDetached: async ({ keyId, data, signature }) => {
+      const { sign } = await getSodiumKeysFromIdentifier(keyId)
       return sodium.verifyDetached({ message: data, sig: signature, publicKey: sign.publicKey })
     },
-    encryptSecretBox: async ({ data }) => {
+    encryptSecretBox: async ({ keyId, data }) => {
+      const { privateKey: sodiumSeed } = getPrivateHDKey(keyId)
       return sodium.encryptSecret(data, sodiumSeed)
     },
-    decryptSecretBox: async ({ data }) => {
+    decryptSecretBox: async ({ keyId, data }) => {
+      const { privateKey: sodiumSeed } = getPrivateHDKey(keyId)
       return sodium.decryptSecret(data, sodiumSeed)
     },
-    encryptBox: async ({ data, toPublicKey }) => {
-      const { box } = await sodiumKeysPromise
+    encryptBox: async ({ keyId, data, toPublicKey }) => {
+      const { box } = await getSodiumKeysFromIdentifier(keyId)
       return sodium.encryptBox(data, toPublicKey, box.privateKey)
     },
-    decryptBox: async ({ data, fromPublicKey }) => {
-      const { box } = await sodiumKeysPromise
+    decryptBox: async ({ keyId, data, fromPublicKey }) => {
+      const { box } = await getSodiumKeysFromIdentifier(keyId)
       return sodium.decryptBox(data, fromPublicKey, box.privateKey)
     },
     encryptSealedBox: async ({ data, toPublicKey }) => {
       return sodium.encryptSealedBox(data, toPublicKey)
     },
-    decryptSealedBox: async ({ data }) => {
-      const { box } = await sodiumKeysPromise
+    decryptSealedBox: async ({ keyId, data }) => {
+      const { box } = await getSodiumKeysFromIdentifier(keyId)
       return sodium.decryptSealedBox(data, box.publicKey, box.privateKey)
     },
   })
+
+  // For backwards compatibility
+  // Remove after createSodiumEncryptor is deprecated
+  const createEncryptor = ({ keyId }) => {
+    const instance = createInstance()
+    const encryptor = mapValues(instance, (fn) => async (args) => fn({ ...args, keyId }))
+    return Object.freeze(encryptor)
+  }
+
+  return Object.freeze({ ...createInstance(), createEncryptor })
 }
 
 export const privToPub = async (sodiumSeed) => {

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -5,7 +5,7 @@ import SLIP10 from '@exodus/slip10'
 import { mapValues } from '@exodus/basic-utils'
 import assert from 'minimalistic-assert'
 
-import { createEd25519Signer } from './crypto/ed25519'
+import * as ed25519 from './crypto/ed25519'
 import { createSecp256k1Signer } from './crypto/secp256k1'
 import * as sodium from './crypto/sodium'
 import {
@@ -39,6 +39,7 @@ export class Keychain extends ExodusModule {
     Object.freeze(this.#legacyPrivToPub)
 
     this.sodium = sodium.create({ getPrivateHDKey: this.#getPrivateHDKey })
+    this.ed25519 = ed25519.create({ getPrivateHDKey: this.#getPrivateHDKey })
   }
 
   unlock({ seed }) {
@@ -108,15 +109,14 @@ export class Keychain extends ExodusModule {
     return signTxWithHD({ unsignedTx, hdkeys, privateKey })
   }
 
-  /** @deprecated */
+  // @deprecated use keychain.sodium instead
   createSodiumEncryptor(keyId) {
     return this.sodium.createEncryptor({ keyId })
   }
 
-  // Ed25519 EdDSA
+  // @deprecated use keychain.ed25519 instead
   createEd25519Signer(keyId) {
-    const { privateKey } = this.#getPrivateHDKey(keyId)
-    return createEd25519Signer(privateKey)
+    return this.ed25519.createSigner({ keyId })
   }
 
   // Secp256k1 EcDSA

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -37,6 +37,8 @@ export class Keychain extends ExodusModule {
     // but at this point in time this is the best we can do.
     this.#legacyPrivToPub = Object.assign(Object.create(null), legacyPrivToPub)
     Object.freeze(this.#legacyPrivToPub)
+
+    this.sodium = sodium.create({ getPrivateHDKey: this.#getPrivateHDKey })
   }
 
   unlock({ seed }) {
@@ -106,9 +108,9 @@ export class Keychain extends ExodusModule {
     return signTxWithHD({ unsignedTx, hdkeys, privateKey })
   }
 
+  /** @deprecated */
   createSodiumEncryptor(keyId) {
-    const { privateKey: sodiumSeed } = this.#getPrivateHDKey(keyId)
-    return sodium.createSodiumEncryptor(sodiumSeed)
+    return this.sodium.createEncryptor({ keyId })
   }
 
   // Ed25519 EdDSA

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -6,7 +6,7 @@ import { mapValues } from '@exodus/basic-utils'
 import assert from 'minimalistic-assert'
 
 import * as ed25519 from './crypto/ed25519'
-import { createSecp256k1Signer } from './crypto/secp256k1'
+import * as secp256k1 from './crypto/secp256k1'
 import * as sodium from './crypto/sodium'
 import {
   throwIfInvalidKeyIdentifier,
@@ -40,6 +40,7 @@ export class Keychain extends ExodusModule {
 
     this.sodium = sodium.create({ getPrivateHDKey: this.#getPrivateHDKey })
     this.ed25519 = ed25519.create({ getPrivateHDKey: this.#getPrivateHDKey })
+    this.secp256k1 = secp256k1.create({ getPrivateHDKey: this.#getPrivateHDKey })
   }
 
   unlock({ seed }) {
@@ -119,10 +120,9 @@ export class Keychain extends ExodusModule {
     return this.ed25519.createSigner({ keyId })
   }
 
-  // Secp256k1 EcDSA
+  // @deprecated use keychain.secp256k1 instead
   createSecp256k1Signer(keyId) {
-    const { privateKey } = this.#getPrivateHDKey(keyId)
-    return createSecp256k1Signer(privateKey)
+    return this.secp256k1.createSigner({ keyId })
   }
 
   clone() {


### PR DESCRIPTION
Depends on: https://github.com/ExodusMovement/exodus-oss/pull/20

Don't panic about line changes 😄 Most of them are tests to ensure things work as expected

There are some keychain methods that do not adjust to the distributed architecture we are trying to push forward. These are:

- createSodiumEncryptor
- createEd15519Signer
- create Secp256k1Signer

This PR exposes the same apis in `keychain.sodium`, `keychain.ed15519` and `keychain.secp256k1`, without deprecating the old ones so we can gradually migrate. Main difference of these apis is we need to pass keyId to each method, which I think it's fine.

It's possible these new methods have a small performance regression given we previously reused the `sodium.getSodiumKeysFromSeed(privateKey)` instance. Not sure if this design decision was related to performance specifically (@kewde do you know?), but either way, the same is achievable if we internally cache instances by keyId (we will ideally need to add a `toString()` method to `KeyIdentifier` to do so). Decided to leave this out in this PR, but if it's critical I can add it in a following one so this does not end up being very big.

@mvayngrib @kewde thoughts about this approach?