### PR TITLE
chore: bring back label, merge conflict detection action

### DIFF
--- a/.github/workflows/conflicts.yaml
+++ b/.github/workflows/conflicts.yaml
@@ -1,0 +1,26 @@
+name: Rebase Conflicts
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conflicts:
+    name: Check for Conflicts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PRs
+        uses: ExodusMovement/actions-label-merge-conflict@main
+        with:
+          dirtyLabel: 'blocked/needs-rebase'
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          commentOnDirty: 'Houston, this is Conflict Bot. We have a conflict. I repeat, we have a conflict. @<%= author %> please rebase. Acknowledge.'
+          retryAfter: 45
+          removeDirtyComment: true

--- a/.github/workflows/conflicts.yaml
+++ b/.github/workflows/conflicts.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [synchronize]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/conflicts.yaml
+++ b/.github/workflows/conflicts.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PRs
-        uses: ExodusMovement/actions-label-merge-conflict@main
+        uses: ExodusMovement/actions-label-merge-conflict@71abef2871620db9447045b06bcd150ed607dc13
         with:
           dirtyLabel: 'blocked/needs-rebase'
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -3,6 +3,9 @@ name: Label
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   label:
     name: PR

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,0 +1,19 @@
+name: Label
+
+on:
+  pull_request:
+
+jobs:
+  label:
+    name: PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Package Names
+        uses: ExodusMovement/lerna-package-name-action@8ab1e30ccb854ba24499b15ec0b7def7c9c12bf2
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Categories
+        uses: actions/labeler@v4


### PR DESCRIPTION
bring back, lock down to commit hash

reverted in #26, but has now been reviewed