### PR TITLE
fix(keychain): super.clear() call

### DIFF
--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -129,7 +129,7 @@ export class Keychain extends ExodusModule {
     return new Keychain({ legacyPrivToPub: this.#legacyPrivToPub })
   }
 
-  clear = async () => {
+  async clear() {
     // noop
   }
 }


### PR DESCRIPTION
Calling `super.clear()` on child class does not work on arrow functions 😞 