### PR TITLE
chore: fix prettier log-level flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test:integration": "lerna run test:integration",
     "coverage:merge": "lerna run coverage:merge",
     "build": "lerna run build",
-    "format": "prettier --write \"**/*.{json,md,yaml}\" --loglevel warn",
-    "format:check": "prettier --check \"**/*.{json,md,yaml}\" --loglevel warn",
+    "format": "prettier --write \"**/*.{json,md,yaml}\" --log-level warn",
+    "format:check": "prettier --check \"**/*.{json,md,yaml}\" --log-level warn",
     "cache:delete": "node ./tools/scripts/cache/delete",
     "sync": "./tools/scripts/sync.js"
   },


### PR DESCRIPTION
## Summary

it's `log-level`, not `loglevel`. Today we get a warning in `format` and `format:check` scripts
> [warn] Ignored unknown option --loglevel=warn. Did you mean --log-level?

## Test Plan

- [ ] `yarn format:check` complains on master and doesn't here
- [ ] `yarn format` complains on master and doesn't here