### PR TITLE
feat(key-identifier): add meaningful `toString()`

### DIFF
--- a/features/keychain/module/__tests__/key-identifier.test.js
+++ b/features/keychain/module/__tests__/key-identifier.test.js
@@ -103,6 +103,18 @@ describe('KeyIdentifier', () => {
       expect(KeyIdentifier.compare('not-an-object', keyIdB)).toBe(false)
     })
   })
+
+  describe('.toString()', () => {
+    it('should show derivation path and algorithm', () => {
+      const keyIdentifier = new KeyIdentifier({
+        derivationAlgorithm: 'SLIP10',
+        assetName: 'solana',
+        derivationPath: "m/44'/501'/0'",
+      })
+
+      expect(keyIdentifier.toString()).toBe("m/44'/501'/0' (SLIP10)")
+    })
+  })
 })
 
 describe('createKeyIdentifierForExodus', () => {

--- a/features/keychain/module/key-identifier.js
+++ b/features/keychain/module/key-identifier.js
@@ -43,6 +43,10 @@ export class KeyIdentifier {
     Object.freeze(this)
   }
 
+  toString() {
+    return `${this.derivationPath} (${this.derivationAlgorithm})`
+  }
+
   static validate = (potentialKeyIdentifier) => {
     try {
       // eslint-disable-next-line no-new


### PR DESCRIPTION
Add a `toString()` implementation to the key identifier that shows the derivation path and algorithm. Makes it more convenient to show key identifier information in logs or error messages. Not printing `assetName` as it is only needed for legacy use cases and the coin type part of the derivation path identifies the asset anyway. 