### PR TITLE
chore: release keychain 6.0.0

### DIFF
--- a/features/keychain/CHANGELOG.md
+++ b/features/keychain/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.0](https://github.com/ExodusMovement/exodus-oss/compare/@exodus/keychain@5.0.1...@exodus/keychain@6.0.0) (2024-02-15)
+
+### ⚠ BREAKING CHANGES
+
+- add multi-seed support ([#50](https://github.com/ExodusMovement/exodus-oss/issues/50)) ([82e5cf2e](https://github.com/ExodusMovement/exodus-oss/commit/82e5cf2e1b9334af150bf2a8bba4abbc0f74c764))
+
 ## [5.0.1](https://github.com/ExodusMovement/exodus-oss/compare/@exodus/keychain@5.0.0...@exodus/keychain@5.0.1) (2024-01-26)
 
 ### Bug Fixes

--- a/features/keychain/package.json
+++ b/features/keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/keychain",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "A module designed to work more securely with private key material",
   "author": "Exodus Movement Inc.",
   "homepage": "https://github.com/ExodusMovement/exodus-oss/tree/master/features/keychain",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1810,6 +1810,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@exodus/bip32@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "@exodus/bip32@npm:1.1.2"
+  dependencies:
+    "@exodus/hdkey": 2.1.0-exodus.0
+    bip32-path: ^0.4.2
+    hdkey: 1.1.2
+    lodash: ^4.17.11
+    minimalistic-assert: ^1.0.1
+  checksum: 19671828a66346c57c832715a4b093002f7c673119dcbd7218a9b33d06f15a2b16f3a9d7d72396bbf78c655db42fccfa7336c17625dc7fdd25c89920e99c0946
+  languageName: node
+  linkType: hard
+
 "@exodus/bip32@npm:^2.1.0":
   version: 2.1.0
   resolution: "@exodus/bip32@npm:2.1.0"
@@ -1946,7 +1959,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@exodus/hdkey@npm:^2.1.0-exodus.0":
+"@exodus/hdkey@npm:2.1.0-exodus.0, @exodus/hdkey@npm:^2.1.0-exodus.0":
   version: 2.1.0-exodus.0
   resolution: "@exodus/hdkey@npm:2.1.0-exodus.0"
   dependencies:
@@ -1979,7 +1992,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@exodus/keychain@^5.0.1, @exodus/keychain@workspace:features/keychain":
+"@exodus/keychain@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@exodus/keychain@npm:5.0.1"
+  dependencies:
+    "@exodus/basic-utils": ^2.0.0
+    "@exodus/bip32": ^1.0.0
+    "@exodus/elliptic": ^6.5.4-precomputed
+    "@exodus/key-utils": ^3.0.0
+    "@exodus/module": ^1.2.0
+    "@exodus/slip10": ^1.0.0
+    "@exodus/sodium-crypto": ^3.1.0
+    buffer-json: ^2.0.0
+    json-stable-stringify: ^1.0.1
+    lodash: ^4.17.21
+    minimalistic-assert: ^1.0.1
+  checksum: 1b9f4298de6793f6150371dbb0f3f0cc7877cd00f4a8560642a29c7308a745e9290e5817a83c1a616f45f9b9bbd9e54b74d7fcf6942d0a7c99a536eb25ce6449
+  languageName: node
+  linkType: hard
+
+"@exodus/keychain@workspace:features/keychain":
   version: 0.0.0-use.local
   resolution: "@exodus/keychain@workspace:features/keychain"
   dependencies:
@@ -4351,6 +4383,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bindings@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "bindings@npm:1.5.0"
+  dependencies:
+    file-uri-to-path: 1.0.0
+  checksum: 65b6b48095717c2e6105a021a7da4ea435aa8d3d3cd085cb9e85bcb6e5773cf318c4745c3f7c504412855940b585bdf9b918236612a1c7a7942491de176f1ae7
+  languageName: node
+  linkType: hard
+
 "bip32-path@npm:0.4.2, bip32-path@npm:^0.4.2":
   version: 0.4.2
   resolution: "bip32-path@npm:0.4.2"
@@ -4371,6 +4412,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bip66@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "bip66@npm:1.1.5"
+  dependencies:
+    safe-buffer: ^5.0.1
+  checksum: 956cff6e51d7206571ef8ce875bc5fa61b5c181589790b9155799b7edcae4b20dbb3eed43b188ff3eec27cdbe98e0b7e0ec9f1cb2e4f5370c119028b248ad859
+  languageName: node
+  linkType: hard
+
 "bl@npm:^4.0.3, bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
@@ -4382,7 +4432,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.11.0, bn.js@npm:^4.11.9":
+"bn.js@npm:^4.11.0, bn.js@npm:^4.11.8, bn.js@npm:^4.11.9":
   version: 4.12.0
   resolution: "bn.js@npm:4.12.0"
   checksum: 39afb4f15f4ea537b55eaf1446c896af28ac948fdcf47171961475724d1bb65118cca49fa6e3d67706e4790955ec0e74de584e45c8f1ef89f46c812bee5b5a12
@@ -4421,6 +4471,20 @@ __metadata:
   version: 1.1.0
   resolution: "brorand@npm:1.1.0"
   checksum: 8a05c9f3c4b46572dec6ef71012b1946db6cae8c7bb60ccd4b7dd5a84655db49fe043ecc6272e7ef1f69dc53d6730b9e2a3a03a8310509a3d797a618cbee52be
+  languageName: node
+  linkType: hard
+
+"browserify-aes@npm:^1.0.6":
+  version: 1.2.0
+  resolution: "browserify-aes@npm:1.2.0"
+  dependencies:
+    buffer-xor: ^1.0.3
+    cipher-base: ^1.0.0
+    create-hash: ^1.1.0
+    evp_bytestokey: ^1.0.3
+    inherits: ^2.0.1
+    safe-buffer: ^5.0.1
+  checksum: 4a17c3eb55a2aa61c934c286f34921933086bf6d67f02d4adb09fcc6f2fc93977b47d9d884c25619144fccd47b3b3a399e1ad8b3ff5a346be47270114bcf7104
   languageName: node
   linkType: hard
 
@@ -4501,6 +4565,13 @@ __metadata:
   version: 2.0.0
   resolution: "buffer-json@npm:2.0.0"
   checksum: 9b8601d25f50341a02c42cb7ffbd6d6801d961f2beda5648c86da815b3019dd8503ebf106cdc2ff2b98f78a463d8b6754f6797419d25ec60a90bb9192fccf40c
+  languageName: node
+  linkType: hard
+
+"buffer-xor@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "buffer-xor@npm:1.0.3"
+  checksum: 10c520df29d62fa6e785e2800e586a20fc4f6dfad84bcdbd12e1e8a83856de1cb75c7ebd7abe6d036bbfab738a6cf18a3ae9c8e5a2e2eb3167ca7399ce65373a
   languageName: node
   linkType: hard
 
@@ -4752,7 +4823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cipher-base@npm:^1.0.1, cipher-base@npm:^1.0.3":
+"cipher-base@npm:^1.0.0, cipher-base@npm:^1.0.1, cipher-base@npm:^1.0.3":
   version: 1.0.4
   resolution: "cipher-base@npm:1.0.4"
   dependencies:
@@ -5469,6 +5540,17 @@ __metadata:
   version: 10.0.0
   resolution: "dotenv@npm:10.0.0"
   checksum: f412c5fe8c24fbe313d302d2500e247ba8a1946492db405a4de4d30dd0eb186a88a43f13c958c5a7de303938949c4231c56994f97d05c4bc1f22478d631b4005
+  languageName: node
+  linkType: hard
+
+"drbg.js@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "drbg.js@npm:1.0.1"
+  dependencies:
+    browserify-aes: ^1.0.6
+    create-hash: ^1.1.2
+    create-hmac: ^1.1.4
+  checksum: f8df5cdd4fb792e548d6187cbc446fbd0afd8f1ef7fa486e1c286c2adee55a687183ce48ab178e9f24965c2deabb6e2ba7a7ee2d675264b951356480eb042476
   languageName: node
   linkType: hard
 
@@ -6202,6 +6284,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"evp_bytestokey@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "evp_bytestokey@npm:1.0.3"
+  dependencies:
+    md5.js: ^1.3.4
+    node-gyp: latest
+    safe-buffer: ^5.1.1
+  checksum: ad4e1577f1a6b721c7800dcc7c733fe01f6c310732bb5bf2240245c2a5b45a38518b91d8be2c610611623160b9d1c0e91f1ce96d639f8b53e8894625cf20fa45
+  languageName: node
+  linkType: hard
+
 "execa@npm:5.0.0":
   version: 5.0.0
   resolution: "execa@npm:5.0.0"
@@ -6368,6 +6461,13 @@ __metadata:
   dependencies:
     flat-cache: ^3.0.4
   checksum: f49701feaa6314c8127c3c2f6173cfefff17612f5ed2daaafc6da13b5c91fd43e3b2a58fd0d63f9f94478a501b167615931e7200e31485e320f74a33885a9c74
+  languageName: node
+  linkType: hard
+
+"file-uri-to-path@npm:1.0.0":
+  version: 1.0.0
+  resolution: "file-uri-to-path@npm:1.0.0"
+  checksum: b648580bdd893a008c92c7ecc96c3ee57a5e7b6c4c18a9a09b44fb5d36d79146f8e442578bc0e173dc027adf3987e254ba1dfd6e3ec998b7c282873010502144
   languageName: node
   linkType: hard
 
@@ -7104,6 +7204,17 @@ __metadata:
   dependencies:
     function-bind: ^1.1.2
   checksum: 6151c75ca12554565098641c98a40f4cc86b85b0fd5b6fe92360967e4605a4f9610f7757260b4e8098dd1c2ce7f4b095f2006fe72a570e3b6d2d28de0298c176
+  languageName: node
+  linkType: hard
+
+"hdkey@npm:1.1.2":
+  version: 1.1.2
+  resolution: "hdkey@npm:1.1.2"
+  dependencies:
+    bs58check: ^2.1.2
+    safe-buffer: ^5.1.1
+    secp256k1: ^3.0.1
+  checksum: eacf181e17511b51b3842f752adb266b9f154894293505d188af0e56a8413bb412870a4ae58742863d1df1d9fa5bce987edfd0cdf1d3abbe962e3521c76c33d7
   languageName: node
   linkType: hard
 
@@ -9525,6 +9636,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nan@npm:^2.14.0":
+  version: 2.18.0
+  resolution: "nan@npm:2.18.0"
+  dependencies:
+    node-gyp: latest
+  checksum: 4fe42f58456504eab3105c04a5cffb72066b5f22bd45decf33523cb17e7d6abc33cca2a19829407b9000539c5cb25f410312d4dc5b30220167a3594896ea6a0a
+  languageName: node
+  linkType: hard
+
 "natural-compare-lite@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare-lite@npm:1.4.0"
@@ -11389,6 +11509,23 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
+  languageName: node
+  linkType: hard
+
+"secp256k1@npm:^3.0.1":
+  version: 3.8.0
+  resolution: "secp256k1@npm:3.8.0"
+  dependencies:
+    bindings: ^1.5.0
+    bip66: ^1.1.5
+    bn.js: ^4.11.8
+    create-hash: ^1.2.0
+    drbg.js: ^1.0.1
+    elliptic: ^6.5.2
+    nan: ^2.14.0
+    node-gyp: latest
+    safe-buffer: ^5.1.2
+  checksum: 37aaae687a8de9b7bc733ab26bc89c4302b9c681d69d71d531842d99d3af9301a4e30dbe40122793ec64b7a08b8fee8d2330397b7b2dd3a7e404ed259a458089
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
have to do this manually until we get lerna-release-action back