### PR TITLE
feat: add separate key-identifier package

### DIFF
--- a/features/keychain/README.md
+++ b/features/keychain/README.md
@@ -27,7 +27,7 @@ Check [here](https://github.com/ExodusMovement/exodus-desktop/tree/master/src/ap
 In order to interact with a private key, you must first specify how it's accessed. A `KeyIdentifier` must be created, for assets there is a helpful `KeyIdentifier` class that will do the heavy lifting.
 
 ```js
-import { KeyIdentifier } from '@exodus/keychain/module'
+import KeyIdentifier from '@exodus/key-identifier'
 
 const keyId = new KeyIdentifier({
   assetName: 'solana',

--- a/features/keychain/module/__tests__/compatibility.test.js
+++ b/features/keychain/module/__tests__/compatibility.test.js
@@ -1,6 +1,6 @@
 import { mnemonicToSeed } from 'bip39'
 import { createKeyIdentifierForExodus } from '@exodus/key-ids'
-import { KeyIdentifier } from '../key-identifier'
+import KeyIdentifier from '@exodus/key-identifier'
 import createKeychain from './create-keychain'
 import { getSeedId } from '../crypto/seed-id'
 

--- a/features/keychain/module/__tests__/eddsa.test.js
+++ b/features/keychain/module/__tests__/eddsa.test.js
@@ -1,6 +1,6 @@
 import { mnemonicToSeed } from 'bip39'
 import { createKeyIdentifierForExodus } from '@exodus/key-ids'
-import { KeyIdentifier } from '../key-identifier'
+import KeyIdentifier from '@exodus/key-identifier'
 import createKeychain from './create-keychain'
 import { getSeedId } from '../crypto/seed-id'
 

--- a/features/keychain/module/__tests__/keychain.integration-test.js
+++ b/features/keychain/module/__tests__/keychain.integration-test.js
@@ -10,7 +10,7 @@ import { mnemonicToSeed } from 'bip39'
 import { assets } from './fixtures/assets'
 import simpleTx from './fixtures/simple-tx'
 
-import { KeyIdentifier } from '../key-identifier'
+import KeyIdentifier from '@exodus/key-identifier'
 import keychainDefinition, { Keychain } from '../keychain'
 import { getSeedId } from '../crypto/seed-id'
 

--- a/features/keychain/module/__tests__/sodium.test.js
+++ b/features/keychain/module/__tests__/sodium.test.js
@@ -1,6 +1,6 @@
 import { mnemonicToSeed } from 'bip39'
 
-import { KeyIdentifier } from '../key-identifier'
+import KeyIdentifier from '@exodus/key-identifier'
 import createKeychain from './create-keychain'
 import { getSeedId } from '../crypto/seed-id'
 

--- a/features/keychain/module/index.js
+++ b/features/keychain/module/index.js
@@ -1,2 +1,2 @@
-export { KeyIdentifier } from './key-identifier'
+export { default as KeyIdentifier } from '@exodus/key-identifier'
 export { default, Keychain } from './keychain'

--- a/features/keychain/module/validate.js
+++ b/features/keychain/module/validate.js
@@ -1,7 +1,7 @@
 import assert from 'minimalistic-assert'
+import KeyIdentifier from '@exodus/key-identifier'
 
 import { ExpectedKeyIdentifier, NotInitializedError } from './errors'
-import { KeyIdentifier } from './key-identifier'
 
 export const throwIfInvalidKeyIdentifier = (potentialKeyIdentifier) => {
   if (!KeyIdentifier.validate(potentialKeyIdentifier) || !Object.isFrozen(potentialKeyIdentifier)) {

--- a/features/keychain/package.json
+++ b/features/keychain/package.json
@@ -30,7 +30,7 @@
     "@exodus/basic-utils": "^2.0.0",
     "@exodus/bip32": "^2.1.0",
     "@exodus/elliptic": "^6.5.4-precomputed",
-    "@exodus/key-identifier": "workspace:^",
+    "@exodus/key-identifier": "^1.0.0",
     "@exodus/key-utils": "^3.0.0",
     "@exodus/module": "^1.2.0",
     "@exodus/slip10": "^1.0.0",

--- a/features/keychain/package.json
+++ b/features/keychain/package.json
@@ -30,6 +30,7 @@
     "@exodus/basic-utils": "^2.0.0",
     "@exodus/bip32": "^2.1.0",
     "@exodus/elliptic": "^6.5.4-precomputed",
+    "@exodus/key-identifier": "workspace:^",
     "@exodus/key-utils": "^3.0.0",
     "@exodus/module": "^1.2.0",
     "@exodus/slip10": "^1.0.0",

--- a/libraries/key-identifier/LICENSE
+++ b/libraries/key-identifier/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Exodus Movement, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libraries/key-identifier/README.md
+++ b/libraries/key-identifier/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-In order to interact with a private key, you must first specify how it's accessed. This is done through the `KeyIdentifier` class provided by this library. A key identifier is most notably provided to the keychain for operations such as exporting a key or signing a transaction.
+To interact with a key, you must first specify how to derive it. This is done through the `KeyIdentifier` class provided by this library. A key identifier is most notably provided to the keychain for operations such as exporting a key or signing a transaction.
 
 ```js
 import KeyIdentifier from '@exodus/key-identifier'

--- a/libraries/key-identifier/README.md
+++ b/libraries/key-identifier/README.md
@@ -1,0 +1,21 @@
+# @exodus/key-identifier
+
+## Usage
+
+In order to interact with a private key, you must first specify how it's accessed. This is done through the `KeyIdentifier` class provided by this library. A key identifier is most notably provided to the keychain for operations such as exporting a key or signing a transaction.
+
+```js
+import KeyIdentifier from '@exodus/key-identifier'
+
+const keyId = new KeyIdentifier({
+  derivationAlgorithm: 'BIP32',
+  derivationPath: "m/44'/501'/0'/0/0",
+  keyType: 'nacl',
+})
+
+const { privateKey, publicKey, xpub, xpriv } = await keychain.exportKey({
+  seedId,
+  keyId,
+  exportPrivate: true,
+})
+```

--- a/libraries/key-identifier/__tests__/key-identifier.integration-test.js
+++ b/libraries/key-identifier/__tests__/key-identifier.integration-test.js
@@ -1,35 +1,46 @@
+import { assets } from '../../../features/keychain/module/__tests__/fixtures/assets'
 import { createKeyIdentifierForExodus } from '@exodus/key-ids'
-import { KeyIdentifier } from '../key-identifier'
+import KeyIdentifier from '../src/key-identifier'
 
 describe('KeyIdentifier', () => {
   it('should fail on incorrect construction', () => {
     const failures = [
-      null,
-      undefined,
-      Object.create(null),
-      // Missing parameters
-
       {
         derivationAlgorithm: 'BIP32',
+        asset: assets.ethereum,
       },
       {
         derivationPath: "m/44'/60'/0'/0/0",
+        asset: assets.ethereum,
       },
-
-      // Incorrect types
       {
-        derivationAlgorithm: 'BIP32',
-        assetName: 0,
+        asset: assets.ethereum,
+      },
+      {
+        derivationAlgorithm: 0,
+        asset: assets.ethereum,
         derivationPath: "m/44'/60'/0'/0/0",
       },
-
-      // Non-existing assetNames
-      // {
-      //  derivationAlgorithm: 'BIP32',
-      //  asset: { name: 'i-do-not-exist' },
-      //  derivationPath: `m/44'/60'/0'/0/0`,
-      // },
-      // Incorrect paths
+      {
+        derivationAlgorithm: 'BIP32',
+        asset: assets.ethereum,
+        derivationPath: 0,
+      },
+      {
+        derivationAlgorithm: 'BIP32',
+        asset: assets.ethereum,
+        derivationPath: "m/44'/60'/0'/0/0dddd",
+      },
+      {
+        derivationAlgorithm: 'BIP32',
+        asset: assets.ethereum,
+        derivationPath: "m\\44'/60'/0'/0/0",
+      },
+      {
+        derivationAlgorithm: 'BIP32',
+        asset: assets.ethereum,
+        derivationPath: "m44'/60'/0'/0/0",
+      },
     ]
 
     const failuresAsFunctions = failures.map((failure) => () => {
@@ -102,18 +113,6 @@ describe('KeyIdentifier', () => {
 
       expect(KeyIdentifier.compare(keyIdA, keyIdB)).toBe(false)
       expect(KeyIdentifier.compare('not-an-object', keyIdB)).toBe(false)
-    })
-  })
-
-  describe('.toString()', () => {
-    it('should show derivation path and algorithm', () => {
-      const keyIdentifier = new KeyIdentifier({
-        derivationAlgorithm: 'SLIP10',
-        assetName: 'solana',
-        derivationPath: "m/44'/501'/0'",
-      })
-
-      expect(keyIdentifier.toString()).toBe("m/44'/501'/0' (SLIP10)")
     })
   })
 })

--- a/libraries/key-identifier/__tests__/key-identifier.test.js
+++ b/libraries/key-identifier/__tests__/key-identifier.test.js
@@ -1,46 +1,35 @@
-import { assets } from './fixtures/assets'
 import { createKeyIdentifierForExodus } from '@exodus/key-ids'
-import { KeyIdentifier } from '../key-identifier'
+import KeyIdentifier from '../src/key-identifier'
 
 describe('KeyIdentifier', () => {
   it('should fail on incorrect construction', () => {
     const failures = [
+      null,
+      undefined,
+      Object.create(null),
+      // Missing parameters
+
       {
         derivationAlgorithm: 'BIP32',
-        asset: assets.ethereum,
       },
       {
         derivationPath: "m/44'/60'/0'/0/0",
-        asset: assets.ethereum,
       },
+
+      // Incorrect types
       {
-        asset: assets.ethereum,
-      },
-      {
-        derivationAlgorithm: 0,
-        asset: assets.ethereum,
+        derivationAlgorithm: 'BIP32',
+        assetName: 0,
         derivationPath: "m/44'/60'/0'/0/0",
       },
-      {
-        derivationAlgorithm: 'BIP32',
-        asset: assets.ethereum,
-        derivationPath: 0,
-      },
-      {
-        derivationAlgorithm: 'BIP32',
-        asset: assets.ethereum,
-        derivationPath: "m/44'/60'/0'/0/0dddd",
-      },
-      {
-        derivationAlgorithm: 'BIP32',
-        asset: assets.ethereum,
-        derivationPath: "m\\44'/60'/0'/0/0",
-      },
-      {
-        derivationAlgorithm: 'BIP32',
-        asset: assets.ethereum,
-        derivationPath: "m44'/60'/0'/0/0",
-      },
+
+      // Non-existing assetNames
+      // {
+      //  derivationAlgorithm: 'BIP32',
+      //  asset: { name: 'i-do-not-exist' },
+      //  derivationPath: `m/44'/60'/0'/0/0`,
+      // },
+      // Incorrect paths
     ]
 
     const failuresAsFunctions = failures.map((failure) => () => {
@@ -113,6 +102,18 @@ describe('KeyIdentifier', () => {
 
       expect(KeyIdentifier.compare(keyIdA, keyIdB)).toBe(false)
       expect(KeyIdentifier.compare('not-an-object', keyIdB)).toBe(false)
+    })
+  })
+
+  describe('.toString()', () => {
+    it('should show derivation path and algorithm', () => {
+      const keyIdentifier = new KeyIdentifier({
+        derivationAlgorithm: 'SLIP10',
+        assetName: 'solana',
+        derivationPath: "m/44'/501'/0'",
+      })
+
+      expect(keyIdentifier.toString()).toBe("m/44'/501'/0' (SLIP10)")
     })
   })
 })

--- a/libraries/key-identifier/babel.config.js
+++ b/libraries/key-identifier/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: '../../babel.config.js',
+}

--- a/libraries/key-identifier/jest.config.js
+++ b/libraries/key-identifier/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  ...require('../../jest.config.js'),
+  testMatch: ['**/__tests__/**.test.js'],
+}

--- a/libraries/key-identifier/package.json
+++ b/libraries/key-identifier/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/ExodusMovement/exodus-oss.git"
   },
   "homepage": "https://github.com/ExodusMovement/exodus-oss/tree/master/libraries/key-identifier",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/ExodusMovement/exodus-oss/issues?q=is%3Aissue+is%3Aopen+label%3Akey-identifier"
   },

--- a/libraries/key-identifier/package.json
+++ b/libraries/key-identifier/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@exodus/key-identifier",
+  "version": "1.0.0",
+  "description": "Provides a KeyIdentifier class that helps to define how a key is derived",
+  "author": "Exodus Movement Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ExodusMovement/exodus-oss.git"
+  },
+  "homepage": "https://github.com/ExodusMovement/exodus-oss/tree/master/libraries/key-identifier",
+  "license": "UNLICENSED",
+  "bugs": {
+    "url": "https://github.com/ExodusMovement/exodus-oss/issues?q=is%3Aissue+is%3Aopen+label%3Akey-identifier"
+  },
+  "main": "src/index.js",
+  "files": [
+    "src",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "lint": "yarn run -T eslint . --ignore-path ../../.gitignore",
+    "lint:fix": "yarn lint --fix",
+    "test": "yarn run -T jest"
+  },
+  "dependencies": {
+    "@exodus/key-utils": "^3.1.0",
+    "minimalistic-assert": "^1.0.1"
+  },
+  "devDependencies": {
+    "@exodus/key-ids": "^1.2.0",
+    "@exodus/keychain": "workspace:^"
+  }
+}

--- a/libraries/key-identifier/package.json
+++ b/libraries/key-identifier/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "lint": "yarn run -T eslint . --ignore-path ../../.gitignore",
     "lint:fix": "yarn lint --fix",
-    "test": "yarn run -T jest"
+    "test": "yarn run -T jest",
+    "todo:reenable:test:integration": "jest --testMatch='**/*.integration-test.js'"
   },
   "dependencies": {
     "@exodus/key-utils": "^3.1.0",

--- a/libraries/key-identifier/src/index.js
+++ b/libraries/key-identifier/src/index.js
@@ -1,0 +1,1 @@
+export { default } from './key-identifier'

--- a/libraries/key-identifier/src/key-identifier.js
+++ b/libraries/key-identifier/src/key-identifier.js
@@ -11,7 +11,7 @@ import { assertValidDerivationPath } from '@exodus/key-utils'
 const SUPPORTED_KDFS = new Set(['BIP32', 'SLIP10'])
 const SUPPORTED_KEY_TYPES = new Set(['legacy', 'nacl', 'secp256k1'])
 
-export class KeyIdentifier {
+export default class KeyIdentifier {
   constructor({ derivationAlgorithm, derivationPath, assetName, keyType }) {
     assert(typeof derivationAlgorithm === 'string', 'derivationAlgorithm not a string')
     assert(

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint:fix": "LINTER=true lerna run lint -- --fix",
     "test": "lerna run test -- --passWithNoTests",
     "test:integration": "lerna run test:integration",
+    "todo:reenable:test:integration": "lerna run todo:reenable:test:integration",
     "coverage:merge": "lerna run coverage:merge",
     "build": "lerna run build",
     "format": "prettier --write \"**/*.{json,md,yaml}\" --log-level warn",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1960,6 +1960,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@exodus/key-identifier@workspace:^, @exodus/key-identifier@workspace:libraries/key-identifier":
+  version: 0.0.0-use.local
+  resolution: "@exodus/key-identifier@workspace:libraries/key-identifier"
+  dependencies:
+    "@exodus/key-ids": ^1.2.0
+    "@exodus/key-utils": ^3.1.0
+    "@exodus/keychain": "workspace:^"
+    minimalistic-assert: ^1.0.1
+  languageName: unknown
+  linkType: soft
+
 "@exodus/key-ids@npm:^1.0.0":
   version: 1.0.0
   resolution: "@exodus/key-ids@npm:1.0.0"
@@ -1970,7 +1981,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@exodus/key-utils@npm:^3.0.0":
+"@exodus/key-ids@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@exodus/key-ids@npm:1.2.0"
+  dependencies:
+    "@exodus/keychain": ^5.0.1
+    minimalistic-assert: ^1.0.1
+  checksum: c70f9ffb94773f7cef10cf5f90d54651e510e7be78f685fa999871516dc9e9e7488909022eb4db80d079c7b9d21dd72680ba81bc51d65537a8f1c3145cae2abd
+  languageName: node
+  linkType: hard
+
+"@exodus/key-utils@npm:^3.0.0, @exodus/key-utils@npm:^3.1.0":
   version: 3.1.0
   resolution: "@exodus/key-utils@npm:3.1.0"
   dependencies:
@@ -2000,13 +2021,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@exodus/keychain@workspace:features/keychain":
+"@exodus/keychain@workspace:^, @exodus/keychain@workspace:features/keychain":
   version: 0.0.0-use.local
   resolution: "@exodus/keychain@workspace:features/keychain"
   dependencies:
     "@exodus/basic-utils": ^2.0.0
     "@exodus/bip32": ^2.1.0
     "@exodus/elliptic": ^6.5.4-precomputed
+    "@exodus/key-identifier": "workspace:^"
     "@exodus/key-ids": ^1.0.0
     "@exodus/key-utils": ^3.0.0
     "@exodus/module": ^1.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1960,7 +1960,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@exodus/key-identifier@workspace:^, @exodus/key-identifier@workspace:libraries/key-identifier":
+"@exodus/key-identifier@^1.0.0, @exodus/key-identifier@workspace:libraries/key-identifier":
   version: 0.0.0-use.local
   resolution: "@exodus/key-identifier@workspace:libraries/key-identifier"
   dependencies:
@@ -2028,7 +2028,7 @@ __metadata:
     "@exodus/basic-utils": ^2.0.0
     "@exodus/bip32": ^2.1.0
     "@exodus/elliptic": ^6.5.4-precomputed
-    "@exodus/key-identifier": "workspace:^"
+    "@exodus/key-identifier": ^1.0.0
     "@exodus/key-ids": ^1.0.0
     "@exodus/key-utils": ^3.0.0
     "@exodus/module": ^1.2.0


### PR DESCRIPTION
Extracts the key-identifier to a separate package (`@exodus/key-identifier`) for consumers that don't need or want to pull in the entire keychain. 

Closes https://github.com/ExodusMovement/exodus-hydra/issues/5725

## Testplan
1. run `yarn add @exodus/assets@latest @exodus/cardano-lib@^2.0.3 @exodus/ethereum-lib@^3.3.6 @exodus/models@^11.5.0 @exodus/solana-lib@^1.3.11 @exodus/solana-meta@^1.0.2 @exodus/storage-memory@^2.1.1` at the repo root
2. run `yarn todo:reenable:test:integration`, tests should pass

