### PR TITLE
refactor: do not extend ExodusModule

### DIFF
--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -1,4 +1,3 @@
-import ExodusModule from '@exodus/module'
 import KeyIdentifier from '@exodus/key-identifier'
 import { parseDerivationPath } from '@exodus/key-utils'
 import { fromMasterSeed as bip32FromMasterSeed } from '@exodus/bip32'
@@ -23,14 +22,12 @@ const MAP_KDF = Object.freeze({
 
 export const MODULE_ID = 'keychain'
 
-export class Keychain extends ExodusModule {
+export class Keychain {
   #masters = Object.create(null)
   #legacyPrivToPub = null
 
   // TODO: remove default param. Use it temporarily for backward compatibility.
-  constructor({ legacyPrivToPub = Object.create(null), logger }) {
-    super({ name: MODULE_ID, logger })
-
+  constructor({ legacyPrivToPub = Object.create(null) }) {
     throwIfInvalidLegacyPrivToPub(legacyPrivToPub)
 
     // Create a safe, cloned, frozen map of what was passed to us.
@@ -150,7 +147,7 @@ const keychainDefinition = {
   id: MODULE_ID,
   type: 'module',
   factory: createKeychain,
-  dependencies: ['legacyPrivToPub', 'logger'],
+  dependencies: ['legacyPrivToPub'],
 }
 
 export default keychainDefinition

--- a/features/keychain/module/memoized-keychain.js
+++ b/features/keychain/module/memoized-keychain.js
@@ -5,7 +5,6 @@ import { Keychain } from './keychain'
 
 const keyIdToCacheKey = stableStringify
 
-const MODULE_ID = 'memoizedKeychain'
 const CACHE_KEY = 'data'
 
 const getPublicKeyData = ({ xpub, publicKey }) => ({ xpub, publicKey })
@@ -15,15 +14,15 @@ class MemoizedKeychain extends Keychain {
   #publicKeys = Object.create(null)
   #cloneOpts
 
-  constructor({ storage, logger }) {
-    super({ id: MODULE_ID, logger })
+  constructor({ storage, legacyPrivToPub }) {
+    super({ legacyPrivToPub })
 
     this.#storage = storage
     this.#storage.get(CACHE_KEY).then((data) => {
       this.#publicKeys = data ? BJSON.parse(data) : Object.create(null)
     })
 
-    this.#cloneOpts = { storage, logger }
+    this.#cloneOpts = { storage }
   }
 
   #getCachedKey = async (keyId) => {
@@ -61,7 +60,7 @@ const memoizedKeychainDefinition = {
   id: 'keychain',
   type: 'module',
   factory: (opts) => new MemoizedKeychain(opts),
-  dependencies: ['storage', 'logger'],
+  dependencies: ['storage', 'legacyPrivToPub'],
 }
 
 export default memoizedKeychainDefinition

--- a/features/keychain/package.json
+++ b/features/keychain/package.json
@@ -33,7 +33,6 @@
     "@exodus/elliptic": "^6.5.4-precomputed",
     "@exodus/key-identifier": "^1.0.0",
     "@exodus/key-utils": "^3.0.0",
-    "@exodus/module": "^1.2.0",
     "@exodus/slip10": "^1.0.0",
     "@exodus/sodium-crypto": "^3.1.0",
     "buffer-json": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,7 +2031,6 @@ __metadata:
     "@exodus/key-identifier": ^1.0.0
     "@exodus/key-ids": ^1.0.0
     "@exodus/key-utils": ^3.0.0
-    "@exodus/module": ^1.2.0
     "@exodus/slip10": ^1.0.0
     "@exodus/sodium-crypto": ^3.1.0
     bip39: 2.6.0


### PR DESCRIPTION
Stop extending `ExodusModule` in keychain as we neither use the EventEmitter nor the logger part of it.

Not marking this as breaking because we never emitted events from keychain, so there cannot be any consumers. 