### PR TITLE
feat: expose `sodium.{signDetached,getKeysFromSeed}`

### DIFF
--- a/features/keychain/api/__tests__/index.test.js
+++ b/features/keychain/api/__tests__/index.test.js
@@ -113,4 +113,35 @@ describe('keychain api', () => {
       xpub: 'xpub6GZDo9NGhuCMi1tATK1mrkcCmsJkS7byjwVgjqp1pZxD1EQ4GMf9vD42r1jAM7teWuk63fPXDvWA8sBxrdVM9sEdhsbGH7jfCEgTg7mvVNh',
     })
   })
+
+  describe('sodium', () => {
+    const EXO = Number.parseInt(Buffer.from('exo').toString('hex'), '16')
+    const keyId = new KeyIdentifier({
+      __proto__: null,
+      derivationAlgorithm: 'SLIP10',
+      derivationPath: `m/${EXO}'/5'/0'`,
+      keyType: 'nacl',
+    })
+
+    test('signDetached signs data', async () => {
+      const data = Buffer.from("Batman's identity was revealed as Harvey Dent")
+      const signature = await api.sodium.signDetached({ seedId, keyId, data })
+
+      expect(signature.toString('hex')).toBe(
+        '5554a24c0885288135f5a4e6bc77b8e84c5e0a836b43b8ea578e3eef890e7d3a4b224d1a9b24960316c626546ff410d1bec918ddb455921c62acbc617c0c2d05'
+      )
+    })
+
+    test('getKeysFromSeed returns public keys', async () => {
+      const keys = await api.sodium.getKeysFromSeed({ seedId, keyId })
+
+      expect(keys.secret).toBeUndefined()
+      expect(keys.sign.publicKey.toString('hex')).toBe(
+        '8154e21fbe0a6b3bd023b649114225633e472b61a8a011ac8385f668863f0439'
+      )
+      expect(keys.box.publicKey.toString('hex')).toBe(
+        '250f5d2b0d4639b17eb68dc71f68fb69f7ef1d3c592a37c15b45be72f29c0358'
+      )
+    })
+  })
 })

--- a/features/keychain/api/index.js
+++ b/features/keychain/api/index.js
@@ -1,10 +1,7 @@
 const createKeychainApi = ({ keychain }) => {
-  const exportKey = async ({ seedId, keyId, exportPrivate }) =>
-    keychain.exportKey({ seedId, keyId, exportPrivate })
-
   return {
     keychain: {
-      exportKey,
+      exportKey: (...args) => keychain.exportKey(...args),
     },
   }
 }

--- a/features/keychain/api/index.js
+++ b/features/keychain/api/index.js
@@ -2,6 +2,13 @@ const createKeychainApi = ({ keychain }) => {
   return {
     keychain: {
       exportKey: (...args) => keychain.exportKey(...args),
+      sodium: {
+        signDetached: keychain.sodium.signDetached,
+        getKeysFromSeed: (...args) =>
+          keychain.sodium
+            .getSodiumKeysFromSeed(...args)
+            .then(({ secret, ...publicKeys }) => publicKeys),
+      },
     },
   }
 }


### PR DESCRIPTION
Expose additional methods on the keychain API, to prepare for the use case where keychain will run in an isolated process and has to work over the wire via RPC. We will no longer be able to support the following usage from the outside as we have no way of serializing this and the key material should also not leave the isolated process:
```js
const sodiumEncryptor = this.#keychain.sodium.createEncryptor({ keyId: KEY_ID }) 
```