### PR TITLE
feat: add get public key to ed25519 signer

### DIFF
--- a/features/keychain/module/crypto/_utils.js
+++ b/features/keychain/module/crypto/_utils.js
@@ -1,0 +1,5 @@
+export const cloneBuffer = (buf) => {
+  const newBuffer = Buffer.alloc(buf.length)
+  buf.copy(newBuffer)
+  return newBuffer
+}

--- a/features/keychain/module/crypto/ed25519.js
+++ b/features/keychain/module/crypto/ed25519.js
@@ -1,5 +1,6 @@
 import sodium from '@exodus/sodium-crypto'
 import { mapValues } from '@exodus/basic-utils'
+import { cloneBuffer } from './_utils'
 
 export const create = ({ getPrivateHDKey }) => {
   const getSodiumKeysFromIdentifier = async ({ seedId, keyId }) => {
@@ -11,6 +12,10 @@ export const create = ({ getPrivateHDKey }) => {
     signBuffer: async ({ seedId, keyId, data }) => {
       const { sign } = await getSodiumKeysFromIdentifier({ seedId, keyId })
       return sodium.signDetached({ message: data, privateKey: sign.privateKey })
+    },
+    getPublicKey: async ({ seedId, keyId }) => {
+      const { sign } = await getSodiumKeysFromIdentifier({ seedId, keyId })
+      return cloneBuffer(sign.publicKey)
     },
   })
 

--- a/features/keychain/module/crypto/sodium.js
+++ b/features/keychain/module/crypto/sodium.js
@@ -1,11 +1,6 @@
 import sodium from '@exodus/sodium-crypto'
 import { mapValues } from '@exodus/basic-utils'
-
-const cloneBuffer = (buf) => {
-  const newBuffer = Buffer.alloc(buf.length)
-  buf.copy(newBuffer)
-  return newBuffer
-}
+import { cloneBuffer } from './_utils'
 
 export const create = ({ getPrivateHDKey }) => {
   // Sodium encryptor caches the private key and the return value holds


### PR DESCRIPTION
There doesn't seem to be a good way to get to the public key of the ec25519 signer.

For secp256k1 we can use `keychain.exportKey()`, for `sodium` we can use `keychain.sodium.getSodiumKeysFromSeed()`. Maybe it would make sense to give every singer a `getPublicKey` function.