### PR TITLE
feat: lockPrivateKeys and unlockPrivateKeys

### DIFF
--- a/features/keychain/module/__tests__/lock-private-keys.test.js
+++ b/features/keychain/module/__tests__/lock-private-keys.test.js
@@ -93,6 +93,11 @@ describe('lockPrivateKeys', () => {
     )
   })
 
+  it('should block unlock when already unlocked', async () => {
+    const keychain = createKeychain({ seed })
+    await expect(async () => keychain.unlockPrivateKeys([seed])).rejects.toThrow(/already unlocked/)
+  })
+
   it('should block unlock for wrong seed ids', async () => {
     const keychain = createKeychain({ seed })
     keychain.lockPrivateKeys()

--- a/features/keychain/module/__tests__/lock-private-keys.test.js
+++ b/features/keychain/module/__tests__/lock-private-keys.test.js
@@ -1,0 +1,114 @@
+import { mnemonicToSeed } from 'bip39'
+import { createKeyIdentifierForExodus } from '@exodus/key-ids'
+import KeyIdentifier from '@exodus/key-identifier'
+import createKeychain from './create-keychain'
+import { getSeedId } from '../crypto/seed-id'
+
+const seed = mnemonicToSeed(
+  'menu memory fury language physical wonder dog valid smart edge decrease worth'
+)
+
+const seedId = getSeedId(seed)
+
+describe('lockPrivateKeys', () => {
+  it('should allow private key usage when unlocked', async () => {
+    const keychain = createKeychain({ seed })
+    const keyId = createKeyIdentifierForExodus({ exoType: 'FUSION' })
+    const exportedKeys = await keychain.exportKey({
+      seedId,
+      keyId,
+      exportPrivate: true,
+    })
+
+    // Public keys should be the same
+    const sodiumEncryptor = keychain.createSodiumEncryptor(keyId)
+    const {
+      sign: { publicKey },
+    } = await sodiumEncryptor.getSodiumKeysFromSeed({ seedId })
+    expect(Buffer.compare(publicKey, exportedKeys.publicKey)).toBe(0)
+  })
+
+  it('should allow addSeed when locked', async () => {
+    const keychain = createKeychain({ seed })
+    keychain.lockPrivateKeys()
+    keychain.addSeed(seed)
+  })
+
+  it('should allow addSeeds when locked', async () => {
+    const keychain = createKeychain({ seed })
+    keychain.lockPrivateKeys()
+    keychain.addSeeds([seed])
+  })
+
+  it('should allow removeAllSeeds when locked', async () => {
+    const keychain = createKeychain({ seed })
+    keychain.lockPrivateKeys()
+    keychain.removeAllSeeds()
+  })
+
+  it('should allow exportKey for public keys when locked', async () => {
+    const keychain = createKeychain({ seed })
+    keychain.lockPrivateKeys()
+    const keyId = createKeyIdentifierForExodus({ exoType: 'FUSION' })
+    const exportedKeys = await keychain.exportKey({
+      seedId,
+      keyId,
+    })
+
+    expect(!!exportedKeys.publicKey).toBe(true)
+  })
+
+  it('should block exportKey for private keys when locked', async () => {
+    const keychain = createKeychain({ seed })
+    keychain.lockPrivateKeys()
+    const keyId = createKeyIdentifierForExodus({ exoType: 'FUSION' })
+    await expect(
+      keychain.exportKey({
+        seedId,
+        keyId,
+        exportPrivate: true,
+      })
+    ).rejects.toThrow(/private keys are not locked/)
+  })
+
+  it('should block signTx when locked', async () => {
+    const keychain = createKeychain({ seed })
+    keychain.lockPrivateKeys()
+    await expect(keychain.signTx({})).rejects.toThrow(/private keys are not locked/)
+  })
+
+  it('should block clone when locked', async () => {
+    const keychain = createKeychain({ seed })
+    keychain.lockPrivateKeys()
+    await expect(async () => keychain.clone()).rejects.toThrow(/private keys are not locked/)
+  })
+
+  it('should block sodium when locked', async () => {
+    const keychain = createKeychain({ seed })
+    keychain.lockPrivateKeys()
+    await expect(keychain.sodium.getSodiumKeysFromSeed({})).rejects.toThrow(
+      /private keys are not locked/
+    )
+    await expect(keychain.createSodiumEncryptor({}).getSodiumKeysFromSeed({})).rejects.toThrow(
+      /private keys are not locked/
+    )
+  })
+
+  it('should block ed25519 when locked', async () => {
+    const keychain = createKeychain({ seed })
+    keychain.lockPrivateKeys()
+    await expect(keychain.ed25519.signBuffer({})).rejects.toThrow(/private keys are not locked/)
+    await expect(keychain.createEd25519Signer({}).signBuffer({})).rejects.toThrow(
+      /private keys are not locked/
+    )
+  })
+
+  it('should block secp256k1 when locked', async () => {
+    const keychain = createKeychain({ seed })
+    keychain.lockPrivateKeys()
+    await expect(keychain.secp256k1.signBuffer({})).rejects.toThrow(/private keys are not locked/)
+    await expect(keychain.createSecp256k1Signer({}).signBuffer({})).rejects.toThrow(
+      /private keys are not locked/
+    )
+  })
+})

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -84,6 +84,7 @@ export class Keychain {
   }
 
   #getPrivateHDKey = ({ seedId, keyId }) => {
+    assert(!this.#lockedPrivateKeys, 'private keys are not locked')
     throwIfInvalidKeyIdentifier(keyId)
 
     assert(typeof seedId === 'string', 'seedId must be a BIP32 key identifier in hex encoding')
@@ -125,6 +126,7 @@ export class Keychain {
   }
 
   async signTx({ seedId, keyIds, signTxCallback, unsignedTx }) {
+    assert(!this.#lockedPrivateKeys, 'private keys are not locked')
     assert(typeof signTxCallback === 'function', 'signTxCallback must be a function')
     const hdkeys = Object.fromEntries(
       keyIds.map((keyId) => {

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -42,6 +42,10 @@ export class Keychain {
     this.secp256k1 = secp256k1.create({ getPrivateHDKey: this.#getPrivateHDKey })
   }
 
+  addSeeds(seeds) {
+    return seeds.map((seed) => this.addSeed(seed))
+  }
+
   addSeed(seed) {
     assert(Buffer.isBuffer(seed) && seed.length === 64, 'seed must be buffer of 64 bytes')
     const masters = Object.assign(

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -26,7 +26,7 @@ export class Keychain {
   #masters = Object.create(null)
   #legacyPrivToPub = null
   #lockedPrivateKeys = false
-  #canUsePrivateKeysSymbol = Symbol('canUsePrivateKeys')
+  #getPrivateHDKeySymbol = Symbol('getPrivateHDKey')
 
   // TODO: remove default param. Use it temporarily for backward compatibility.
   constructor({ legacyPrivToPub = Object.create(null) }) {
@@ -84,8 +84,8 @@ export class Keychain {
     this.#masters = Object.create(null)
   }
 
-  #getPrivateHDKey = ({ seedId, keyId, canUsePrivateKeysSymbol }) => {
-    if (canUsePrivateKeysSymbol !== this.#canUsePrivateKeysSymbol)
+  #getPrivateHDKey = ({ seedId, keyId, getPrivateHDKeySymbol }) => {
+    if (getPrivateHDKeySymbol !== this.#getPrivateHDKeySymbol)
       assert(!this.#lockedPrivateKeys, 'private keys are not locked')
     throwIfInvalidKeyIdentifier(keyId)
 
@@ -105,7 +105,7 @@ export class Keychain {
     const hdkey = this.#getPrivateHDKey({
       seedId,
       keyId,
-      canUsePrivateKeysSymbol: this.#canUsePrivateKeysSymbol,
+      getPrivateHDKeySymbol: this.#getPrivateHDKeySymbol,
     })
     const privateKey = hdkey.privateKey
     let publicKey = hdkey.publicKey

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -49,6 +49,7 @@ export class Keychain {
   }
 
   unlockPrivateKeys(seeds) {
+    assert(this.#lockedPrivateKeys, 'already unlocked')
     assert(
       seeds?.length === Object.values(this.#masters).length,
       'must pass in same number of seeds'

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -99,6 +99,7 @@ export class Keychain {
   }
 
   async exportKey({ seedId, keyId, exportPrivate }) {
+    if (exportPrivate) assert(!this.#lockedPrivateKeys, 'private keys are not locked')
     keyId = new KeyIdentifier(keyId)
 
     const hdkey = this.#getPrivateHDKey({

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -166,6 +166,7 @@ export class Keychain {
   }
 
   clone() {
+    assert(!this.#lockedPrivateKeys, 'private keys are not locked')
     return new Keychain({ legacyPrivToPub: this.#legacyPrivToPub })
   }
 

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -44,6 +44,10 @@ export class Keychain {
     this.secp256k1 = secp256k1.create({ getPrivateHDKey: this.#getPrivateHDKey })
   }
 
+  hasLockedPrivateKeys() {
+    return this.#lockedPrivateKeys
+  }
+
   lockPrivateKeys() {
     this.#lockedPrivateKeys = true
   }


### PR DESCRIPTION
# Motivation 

We want an operational mode, that would allow the wallet using the keychain to keep operating, e.g. keep generating addresses & adding portfolios/accounts, but not allow any signing unless the user reenters their authentication. E.g. block sending until password is entered on the send screen.

# What this PR adds

Adds a semi-locked state, which blocks external usage of private keys, but still allows internal usage to generate new public keys. To start using private keys again the keychain needs to be "unlocked". To achieve that securely we force the user to re-add the seeds previously inserted into the keychain, which inherently proves that the user has the permission to view the seeds.

For a use-case where we would also want to remove the seeds from memory for improved security we can use the existing `removeAllSeeds` instead. 

