### PR TITLE
fix: include memory cache on clear

### DIFF
--- a/features/keychain/module/memoized-keychain.js
+++ b/features/keychain/module/memoized-keychain.js
@@ -53,6 +53,7 @@ class MemoizedKeychain extends Keychain {
 
   clear = async () => {
     await super.clear()
+    this.#publicKeys = Object.create(null)
     await this.#storage.delete(CACHE_KEY)
   }
 }


### PR DESCRIPTION
## Summary

This PR resets the private property when calling `.clear()` for `@exodus/keychain` at version `5`.

Mirror of: #81