### PR TITLE
chore: release keychain 5.1.1

### DIFF
--- a/features/keychain/CHANGELOG.md
+++ b/features/keychain/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.1.1](https://github.com/ExodusMovement/exodus-oss/compare/@exodus/keychain@5.1.0...@exodus/keychain@5.1.1) (2024-04-02)
+
+### Bug Fixes
+
+- include memory cache on clear ([#82](https://github.com/ExodusMovement/exodus-oss/pull/82)) ([4dc0e02](https://github.com/ExodusMovement/exodus-oss/commit/4dc0e02729317cba925686b98059f5ac75f231dc))
+
 ## [5.0.2](https://github.com/ExodusMovement/exodus-oss/compare/@exodus/keychain@5.0.0...@exodus/keychain@5.0.2) (2024-04-02)
 
 ### Bug Fixes

--- a/features/keychain/package.json
+++ b/features/keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/keychain",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "A module designed to work more securely with private key material",
   "author": "Exodus Movement Inc.",
   "homepage": "https://github.com/ExodusMovement/exodus-oss/tree/master/features/keychain",


### PR DESCRIPTION
## Summary

Releases the `.clear()` fix from https://github.com/ExodusMovement/exodus-oss/pull/82 for v5.1, too.