### PR TITLE
ci: signed commits

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -26,6 +26,7 @@ on:
 jobs:
   version:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -37,11 +37,21 @@ jobs:
         run: yarn install --immutable
       - name: Prepare
         run: yarn prepare
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@1a317071222a9bfb1839df1b58b1f0dcd893b589
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - name: Version
         uses: ExodusMovement/lerna-release-action/version@931392d04a637dccb561398add594a6cf61255b8
         with:
           github-token: ${{ secrets.GH_AUTOMATION_PAT }}
           packages: ${{ inputs.packages }}
           assignee: ${{ inputs.assignee }}
+          committer: exodus-github-hydra-bot
           version-strategy: ${{ inputs.version-strategy }}
           auto-merge: true

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -48,7 +48,7 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
       - name: Version
-        uses: ExodusMovement/lerna-release-action/version@931392d04a637dccb561398add594a6cf61255b8
+        uses: ExodusMovement/lerna-release-action/version@c4c4b9d747ed0ef2750fa87b86eec3374c1b0e06
         with:
           github-token: ${{ secrets.GH_AUTOMATION_PAT }}
           packages: ${{ inputs.packages }}


### PR DESCRIPTION
Our branch protection rules require us to use signed commits. This adds changes the committer to the bot that creates the PR and enables GPG signing

- [x] Depends on https://github.com/ExodusMovement/lerna-release-action/pull/48
- [x] Create a `release` env and add `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` as secrets

## Testplan
Tested in https://github.com/ExodusMovement/lerna-version-selectively/pull/504