### PR TITLE
feat: add `keyIdentifier.derive()`

### DIFF
--- a/libraries/key-identifier/__tests__/key-identifier.test.js
+++ b/libraries/key-identifier/__tests__/key-identifier.test.js
@@ -22,7 +22,6 @@ describe('KeyIdentifier', () => {
         assetName: 0,
         derivationPath: "m/44'/60'/0'/0/0",
       },
-
       // Non-existing assetNames
       // {
       //  derivationAlgorithm: 'BIP32',
@@ -68,6 +67,53 @@ describe('KeyIdentifier', () => {
 
     valid.forEach((item) => expect(KeyIdentifier.validate(item)).toEqual(true))
     invalid.forEach((item) => expect(KeyIdentifier.validate(item)).toEqual(false))
+  })
+
+  it('supports passing the derivation path as array of path indices', () => {
+    const keyId = new KeyIdentifier({
+      derivationAlgorithm: 'BIP32',
+      assetName: 'ethereum',
+      derivationPath: ['m', "44'", "60'", "0'", '0', '0'],
+    })
+
+    expect(keyId.derivationPath).toBe("m/44'/60'/0'/0/0")
+  })
+
+  describe('.extend()', () => {
+    test('extends derivation path', () => {
+      const keyId = new KeyIdentifier({
+        derivationAlgorithm: 'BIP32',
+        assetName: 'ethereum',
+        derivationPath: "m/44'/60'/0'",
+      })
+
+      const extended = keyId.extend([1, 5])
+
+      expect(extended).toEqual({
+        derivationAlgorithm: 'BIP32',
+        assetName: 'ethereum',
+        keyType: 'secp256k1',
+      })
+
+      expect(extended.derivationPath).toBe("m/44'/60'/0'/1/5")
+    })
+  })
+
+  describe('.toJSON()', () => {
+    test('includes derivation path', () => {
+      const keyId = new KeyIdentifier({
+        derivationAlgorithm: 'BIP32',
+        assetName: 'ethereum',
+        derivationPath: "m/44'/60'/0'",
+      })
+
+      expect(keyId.toJSON()).toEqual({
+        derivationAlgorithm: 'BIP32',
+        assetName: 'ethereum',
+        keyType: 'secp256k1',
+        derivationPath: "m/44'/60'/0'",
+      })
+    })
   })
 
   describe('.compare()', () => {

--- a/libraries/key-identifier/__tests__/key-identifier.test.js
+++ b/libraries/key-identifier/__tests__/key-identifier.test.js
@@ -87,15 +87,15 @@ describe('KeyIdentifier', () => {
         derivationPath: "m/44'/60'/0'",
       })
 
-      const extended = keyId.extend([1, 5])
+      const derived = keyId.derive([1, 5])
 
-      expect(extended).toEqual({
+      expect(derived).toEqual({
         derivationAlgorithm: 'BIP32',
         assetName: 'ethereum',
         keyType: 'secp256k1',
       })
 
-      expect(extended.derivationPath).toBe("m/44'/60'/0'/1/5")
+      expect(derived.derivationPath).toBe("m/44'/60'/0'/1/5")
     })
   })
 

--- a/libraries/key-identifier/package.json
+++ b/libraries/key-identifier/package.json
@@ -25,7 +25,7 @@
     "todo:reenable:test:integration": "jest --testMatch='**/*.integration-test.js'"
   },
   "dependencies": {
-    "@exodus/key-utils": "^3.1.0",
+    "@exodus/key-utils": "^3.3.0",
     "minimalistic-assert": "^1.0.1"
   },
   "devDependencies": {

--- a/libraries/key-identifier/src/key-identifier.d.ts
+++ b/libraries/key-identifier/src/key-identifier.d.ts
@@ -24,7 +24,7 @@ export default class KeyIdentifier {
    * Returns a new KeyIdentifier instance that has an updated derivation path extended with
    * the path indices or partial derivation path supplied to this method
    */
-  extend(pathLike: string | PathIndex[]): KeyIdentifier
+  derive(pathLike: string | PathIndex[]): KeyIdentifier
 
   toJSON(): {
     assetName?: string

--- a/libraries/key-identifier/src/key-identifier.d.ts
+++ b/libraries/key-identifier/src/key-identifier.d.ts
@@ -1,19 +1,37 @@
+type PathIndex = number | string
+type KeyType = 'legacy' | 'nacl' | 'secp2561'
+type DerivationAlgorithm = 'BIP32' | 'SLIP10'
+
 type ConstructorParams = {
-  derivationAlgorithm: 'BIP32' | 'SLIP10'
-  derivationPath: string
+  derivationAlgorithm: DerivationAlgorithm
+  derivationPath: string | PathIndex[]
   assetName?: string
-  keyType: 'legacy' | 'nacl' | 'secp2561'
+  keyType: KeyType
 }
 
 type KeyIdentifierLike = Partial<ConstructorParams>
 
 export default class KeyIdentifier {
-  derivationAlgorithm: ConstructorParams['derivationAlgorithm']
-  derivationPath: ConstructorParams['derivationPath']
-  assetName: ConstructorParams['assetName']
-  keyType: ConstructorParams['keyType']
+  derivationAlgorithm: DerivationAlgorithm
+  keyType: KeyType
+  assetName?: string
 
   constructor(params: ConstructorParams)
+
+  get derivationPath(): string
+
+  /**
+   * Returns a new KeyIdentifier instance that has an updated derivation path extended with
+   * the path indices or partial derivation path supplied to this method
+   */
+  extend(pathLike: string | PathIndex[]): KeyIdentifier
+
+  toJSON(): {
+    assetName?: string
+    derivationAlgorithm: DerivationAlgorithm
+    keyType: KeyType
+    derivationPath: string
+  }
 
   static validate(potentialKeyIdentifier: KeyIdentifierLike): boolean
   static compare(a: KeyIdentifierLike, b: KeyIdentifierLike): boolean

--- a/libraries/key-identifier/src/key-identifier.js
+++ b/libraries/key-identifier/src/key-identifier.js
@@ -48,7 +48,7 @@ export default class KeyIdentifier {
     return this.#derivationPath.toString()
   }
 
-  extend(pathLike) {
+  derive(pathLike) {
     return new KeyIdentifier({
       ...this,
       derivationPath: this.#derivationPath.extend(pathLike),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,7 +1975,7 @@ __metadata:
   resolution: "@exodus/key-identifier@workspace:libraries/key-identifier"
   dependencies:
     "@exodus/key-ids": ^1.2.0
-    "@exodus/key-utils": ^3.1.0
+    "@exodus/key-utils": ^3.3.0
     "@exodus/keychain": "workspace:^"
     minimalistic-assert: ^1.0.1
   languageName: unknown
@@ -2001,7 +2001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@exodus/key-utils@npm:^3.0.0, @exodus/key-utils@npm:^3.1.0":
+"@exodus/key-utils@npm:^3.0.0":
   version: 3.1.0
   resolution: "@exodus/key-utils@npm:3.1.0"
   dependencies:
@@ -2009,6 +2009,18 @@ __metadata:
     bip32-path: ^0.4.2
     minimalistic-assert: ^1.0.1
   checksum: 58776c9f391e549110e18d48e1ce89b70593b50462e0b1253cd35ffbd2f285014f8cff7ba94c4899493439cbf91d7fb6bf5a16e8f2c10a76b2a57c7abd860eca
+  languageName: node
+  linkType: hard
+
+"@exodus/key-utils@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "@exodus/key-utils@npm:3.3.0"
+  dependencies:
+    "@exodus/bip32": ^2.1.0
+    "@exodus/hdkey": ^2.1.0-exodus.0
+    bip32-path: ^0.4.2
+    minimalistic-assert: ^1.0.1
+  checksum: 741e47ac4e2fe285cd984c41dd27508cf2ece46ad53c7afd2f8a6358b9952ef1cedb05839b4f1a3949da19850f051409829f30e45d3fa137856852239018d953
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add `derive` which accepts a partial derivation path and returns a new `KeyIdentifier` instance that has a derivation path that is extended with the supplied path indices.

Captured from https://github.com/ExodusMovement/exodus-hydra/pull/6497/files#r1575088966