### PR TITLE
feat: reject signing with invalid key types

### DIFF
--- a/features/keychain/api/__tests__/index.test.js
+++ b/features/keychain/api/__tests__/index.test.js
@@ -116,20 +116,20 @@ describe('keychain api', () => {
   })
 
   const EXO = Number.parseInt(Buffer.from('exo').toString('hex'), '16')
-  const keyId = new KeyIdentifier({
-    __proto__: null,
-    derivationAlgorithm: 'SLIP10',
-    derivationPath: `m/${EXO}'/5'/0'`,
-    keyType: 'nacl',
-  })
 
   describe('sodium', () => {
+    const keyId = new KeyIdentifier({
+      derivationAlgorithm: 'BIP32',
+      derivationPath: `m/${EXO}'/5'/0'`,
+      keyType: 'secp256k1',
+    })
+
     test('signDetached signs data', async () => {
       const data = Buffer.from("Batman's identity was revealed as Harvey Dent")
       const signature = await api.sodium.signDetached({ seedId, keyId, data })
 
       expect(signature.toString('hex')).toBe(
-        '5554a24c0885288135f5a4e6bc77b8e84c5e0a836b43b8ea578e3eef890e7d3a4b224d1a9b24960316c626546ff410d1bec918ddb455921c62acbc617c0c2d05'
+        'f491a1264bd310c3cc0d412d4dcf2ba144cf99659a025d39b73586fcde6c4e103ccf82574a339f6f9410c57409bbb4b2df723b3bbeadc0a4d7ff3630192cb001'
       )
     })
 
@@ -138,15 +138,22 @@ describe('keychain api', () => {
 
       expect(keys.secret).toBeUndefined()
       expect(keys.sign.publicKey.toString('hex')).toBe(
-        '8154e21fbe0a6b3bd023b649114225633e472b61a8a011ac8385f668863f0439'
+        '5960b9980b740a241dea0d44fe304b196484eab1427ee9e7999b5eeff21cdac9'
       )
       expect(keys.box.publicKey.toString('hex')).toBe(
-        '250f5d2b0d4639b17eb68dc71f68fb69f7ef1d3c592a37c15b45be72f29c0358'
+        '9bb8eb0829e1190d84ea231187be3501a48843446f758ec2b39d262c998d6c4b'
       )
     })
   })
 
   describe('ed25519', () => {
+    const keyId = new KeyIdentifier({
+      __proto__: null,
+      derivationAlgorithm: 'SLIP10',
+      derivationPath: `m/${EXO}'/5'/0'`,
+      keyType: 'nacl',
+    })
+
     test('signBuffer signs binary data', async () => {
       const data = Buffer.from("Batman's identity was revealed as Harvey Dent")
       const signature = await api.ed25519.signBuffer({ seedId, keyId, data })
@@ -158,12 +165,18 @@ describe('keychain api', () => {
   })
 
   describe('secp256k1', () => {
+    const keyId = new KeyIdentifier({
+      derivationAlgorithm: 'BIP32',
+      derivationPath: `m/${EXO}'/5'/0'`,
+      keyType: 'secp256k1',
+    })
+
     test('signBuffer signs binary data', async () => {
       const data = Buffer.from("Batman's identity was revealed as Harvey Dent")
       const signature = await api.secp256k1.signBuffer({ seedId, keyId, data })
 
       expect(signature.toString('hex')).toBe(
-        '3045022100a41633f9330f8cd4f0b84c800f4d80a777bc9210da43132b1571a2753ce7131702200950d1031ddef3149d51a15b1a86c09cf2eac8b3467d76dbd067c117aada7c78'
+        '3044022012305c1fbb450372c3e83217f97f86a5289c8f3e295f61ec65d0acec3393ba8102201714227763f27039e62fc66144db9c1684865574f538dead27d3f0f1e727f328'
       )
     })
   })

--- a/features/keychain/api/__tests__/index.test.js
+++ b/features/keychain/api/__tests__/index.test.js
@@ -148,7 +148,6 @@ describe('keychain api', () => {
 
   describe('ed25519', () => {
     const keyId = new KeyIdentifier({
-      __proto__: null,
       derivationAlgorithm: 'SLIP10',
       derivationPath: `m/${EXO}'/5'/0'`,
       keyType: 'nacl',

--- a/features/keychain/module/__tests__/compatibility.test.js
+++ b/features/keychain/module/__tests__/compatibility.test.js
@@ -42,18 +42,19 @@ describe('compatibility', () => {
       message:
         '010001030bc08d0b03ca1bc9e72e91084d4f001c5e13270acb4fc2853efe7e6b6560b2d85fc00ab3d38d5424af5b90ea447f1f474a1144be96a6d871ee39587522da7239000000000000000000000000000000000000000000000000000000000000000058c46d1f0395440b25e73ab095b539a5b45c7746dd713131e2cfe2755d03958701020200010c0200000000f2052a01000000',
       signature:
-        '1102815ed29faa093f8365870c892e82ee2aff0e7ded7e337dee4e206613355c786b769cf48269e08ae1646ca70974b4bbfdeb0fd5f459f3ef8b4845b8dd6b0f',
+        '90ff0a2a3311957e2920223e1c5b495b731f00834ea431769a5b21cc194a6a7aa14377f1736060f5a685202efe152c18b2db87be300f93fd6a75552464567b00',
     }
 
     const keychain = createKeychain({ seed })
     const keyId = new KeyIdentifier({
       assetName: 'solana',
-      derivationAlgorithm: 'BIP32',
-      derivationPath: "m/44'/501'/0'/0/0",
+      derivationAlgorithm: 'SLIP10',
+      derivationPath: "m/44'/501'/0'/0'/0'",
     })
     const signer = keychain.createEd25519Signer(keyId)
     const signature = await signer.signBuffer({
       seedId,
+      keyId,
       data: Buffer.from(tweetnacl.message, 'hex'),
     })
     expect(signature.toString('hex')).toBe(tweetnacl.signature)

--- a/features/keychain/module/__tests__/eddsa.test.js
+++ b/features/keychain/module/__tests__/eddsa.test.js
@@ -47,13 +47,13 @@ describe('EdDSA Signer', () => {
     const keychain = createKeychain({ seed })
     const keyId = new KeyIdentifier({
       assetName: 'solana',
-      derivationAlgorithm: 'BIP32',
-      derivationPath: "m/44'/501'/0'/0/0",
+      derivationAlgorithm: 'SLIP10',
+      derivationPath: "m/44'/501'/0'/0'/0'",
     })
     const signer = keychain.createEd25519Signer(keyId)
     const signature = await signer.signBuffer({ seedId, data: plaintextTx })
     const expected =
-      '1102815ed29faa093f8365870c892e82ee2aff0e7ded7e337dee4e206613355c786b769cf48269e08ae1646ca70974b4bbfdeb0fd5f459f3ef8b4845b8dd6b0f'
+      '90ff0a2a3311957e2920223e1c5b495b731f00834ea431769a5b21cc194a6a7aa14377f1736060f5a685202efe152c18b2db87be300f93fd6a75552464567b00'
     expect(signature.toString('hex')).toBe(expected)
   })
 
@@ -61,13 +61,31 @@ describe('EdDSA Signer', () => {
     const keychain = createKeychain({ seed })
     const keyId = new KeyIdentifier({
       assetName: 'solana',
-      derivationAlgorithm: 'BIP32',
-      derivationPath: "m/44'/501'/0'/0/0",
+      derivationAlgorithm: 'SLIP10',
+      derivationPath: "m/44'/501'/0'/0'/0'",
     })
     const signature = await keychain.ed25519.signBuffer({ seedId, keyId, data: plaintextTx })
     const expected =
-      '1102815ed29faa093f8365870c892e82ee2aff0e7ded7e337dee4e206613355c786b769cf48269e08ae1646ca70974b4bbfdeb0fd5f459f3ef8b4845b8dd6b0f'
+      '90ff0a2a3311957e2920223e1c5b495b731f00834ea431769a5b21cc194a6a7aa14377f1736060f5a685202efe152c18b2db87be300f93fd6a75552464567b00'
     expect(signature.toString('hex')).toBe(expected)
+  })
+
+  it('should throw for keyType != nacl', async () => {
+    const keychain = createKeychain({ seed })
+    const plaintext = Buffer.from('I really love keychains')
+    const keyId = new KeyIdentifier({
+      derivationPath: 'm/0',
+      keyType: 'secp256k1',
+      derivationAlgorithm: 'BIP32',
+    })
+
+    await expect(
+      keychain.ed25519.signBuffer({
+        seedId,
+        keyId,
+        data: plaintext,
+      })
+    ).rejects.toThrow('ED25519 signatures are not supported for secp256k1')
   })
 })
 
@@ -86,8 +104,8 @@ describe.each([
 ])('EdDSA Signer (multi-seed-keychain)', ({ primarySeed, secondarySeed, seedId }) => {
   const solanaKeyId = new KeyIdentifier({
     assetName: 'solana',
-    derivationAlgorithm: 'BIP32',
-    derivationPath: "m/44'/501'/0'/0/0",
+    derivationAlgorithm: 'SLIP10',
+    derivationPath: "m/44'/501'/0'/0'/0'",
   })
 
   const keychain = createKeychain({ seed: primarySeed })
@@ -112,7 +130,7 @@ describe.each([
     })
 
     const expected =
-      '1102815ed29faa093f8365870c892e82ee2aff0e7ded7e337dee4e206613355c786b769cf48269e08ae1646ca70974b4bbfdeb0fd5f459f3ef8b4845b8dd6b0f'
+      '90ff0a2a3311957e2920223e1c5b495b731f00834ea431769a5b21cc194a6a7aa14377f1736060f5a685202efe152c18b2db87be300f93fd6a75552464567b00'
     expect(signature.toString('hex')).toBe(expected)
   })
 })

--- a/features/keychain/module/__tests__/ethsign.test.js
+++ b/features/keychain/module/__tests__/ethsign.test.js
@@ -1,4 +1,5 @@
 import { create } from '../crypto/secp256k1'
+import KeyIdentifier from '@exodus/key-identifier'
 
 const fixtures = [
   {
@@ -54,6 +55,11 @@ describe('ETH Signer', () => {
       const ethSigner = async (buffer) => {
         const sig = await secp256k1Signer.signBuffer({
           data: buffer,
+          keyId: new KeyIdentifier({
+            keyType: 'secp256k1',
+            derivationPath: 'm/0', // doesn't matter in this fixture as we don't use it
+            derivationAlgorithm: 'BIP32',
+          }),
           ecOptions: { canonical: true },
           enc: 'raw',
         })

--- a/features/keychain/module/__tests__/lock-private-keys.test.js
+++ b/features/keychain/module/__tests__/lock-private-keys.test.js
@@ -2,6 +2,7 @@ import { mnemonicToSeed } from 'bip39'
 import { createKeyIdentifierForExodus } from '@exodus/key-ids'
 import createKeychain from './create-keychain'
 import { getSeedId } from '../crypto/seed-id'
+import KeyIdentifier from '@exodus/key-identifier'
 
 const seed = mnemonicToSeed(
   'menu memory fury language physical wonder dog valid smart edge decrease worth'
@@ -159,17 +160,30 @@ describe('lockPrivateKeys', () => {
   it('should block ed25519 when locked', async () => {
     const keychain = createKeychain({ seed })
     keychain.lockPrivateKeys()
-    await expect(keychain.ed25519.signBuffer({})).rejects.toThrow(/private keys are locked/)
-    await expect(keychain.createEd25519Signer({}).signBuffer({})).rejects.toThrow(
+
+    const keyId = new KeyIdentifier({
+      derivationPath: 'm/0', // doesn't matter in this fixture as we don't use it
+      derivationAlgorithm: 'SLIP10',
+    })
+
+    await expect(keychain.ed25519.signBuffer({ keyId })).rejects.toThrow(/private keys are locked/)
+    await expect(keychain.createEd25519Signer(keyId).signBuffer({})).rejects.toThrow(
       /private keys are locked/
     )
   })
 
   it('should block secp256k1 when locked', async () => {
+    const keyId = new KeyIdentifier({
+      derivationPath: 'm/0', // doesn't matter in this fixture as we don't use it
+      derivationAlgorithm: 'BIP32',
+    })
+
     const keychain = createKeychain({ seed })
     keychain.lockPrivateKeys()
-    await expect(keychain.secp256k1.signBuffer({})).rejects.toThrow(/private keys are locked/)
-    await expect(keychain.createSecp256k1Signer({}).signBuffer({})).rejects.toThrow(
+    await expect(keychain.secp256k1.signBuffer({ keyId })).rejects.toThrow(
+      /private keys are locked/
+    )
+    await expect(keychain.createSecp256k1Signer(keyId).signBuffer({})).rejects.toThrow(
       /private keys are locked/
     )
   })

--- a/features/keychain/module/crypto/ed25519.js
+++ b/features/keychain/module/crypto/ed25519.js
@@ -1,5 +1,6 @@
 import sodium from '@exodus/sodium-crypto'
 import { mapValues } from '@exodus/basic-utils'
+import assert from 'minimalistic-assert'
 
 export const create = ({ getPrivateHDKey }) => {
   const getSodiumKeysFromIdentifier = async ({ seedId, keyId }) => {
@@ -9,6 +10,7 @@ export const create = ({ getPrivateHDKey }) => {
 
   const createInstance = () => ({
     signBuffer: async ({ seedId, keyId, data }) => {
+      assert(keyId.keyType === 'nacl', `ED25519 signatures are not supported for ${keyId.keyType}`)
       const { sign } = await getSodiumKeysFromIdentifier({ seedId, keyId })
       return sodium.signDetached({ message: data, privateKey: sign.privateKey })
     },

--- a/features/keychain/module/crypto/secp256k1.js
+++ b/features/keychain/module/crypto/secp256k1.js
@@ -14,6 +14,10 @@ export const create = ({ getPrivateHDKey }) => {
 
   const createInstance = () => ({
     signBuffer: async ({ seedId, keyId, data, ecOptions, enc = 'der' }) => {
+      assert(
+        keyId.keyType === 'secp256k1',
+        `ECDSA signatures are not supported for ${keyId.keyType}`
+      )
       assert(['der', 'raw'].includes(enc), 'signBuffer: invalid enc')
       assert(isValidEcOptions(ecOptions), 'signBuffer: invalid EC option')
       const { privateKey } = getPrivateHDKey({ seedId, keyId })
@@ -21,6 +25,10 @@ export const create = ({ getPrivateHDKey }) => {
       return enc === 'der' ? Buffer.from(signature.toDER()) : { ...signature }
     },
     signSchnorr: async ({ seedId, keyId, data, tweak, extraEntropy }) => {
+      assert(
+        keyId.keyType === 'secp256k1',
+        `Schnorr signatures are not supported for ${keyId.keyType}`
+      )
       const hdkey = getPrivateHDKey({ seedId, keyId })
       const privateKey = tweak ? tweakPrivateKey({ hdkey, tweak }) : hdkey.privateKey
       return ecc.signSchnorr(data, privateKey, extraEntropy)


### PR DESCRIPTION
This updates our signing functions to throw when they receive an invalid key type, i.e.:

- Schnorr and ECDSA require a secp256k1 key
- ED25519 requires a nacl key

Unfortunately we had many test cases where we provided key identifiers that were not valid for that particular signer (and therefore faild with the new assertion). I updated those 