### PR TITLE
fix: type for `keyType` in `KeyIdentifier`

### DIFF
--- a/libraries/key-identifier/src/key-identifier.d.ts
+++ b/libraries/key-identifier/src/key-identifier.d.ts
@@ -1,5 +1,5 @@
 type PathIndex = number | string
-type KeyType = 'legacy' | 'nacl' | 'secp2561'
+type KeyType = 'legacy' | 'nacl' | 'secp256k1'
 type DerivationAlgorithm = 'BIP32' | 'SLIP10'
 
 type ConstructorParams = {


### PR DESCRIPTION
Type was missing the `k` in `secp256k1`