### PR TITLE
feat: support uncompressed public key

### DIFF
--- a/features/keychain/module/crypto/secp256k1.js
+++ b/features/keychain/module/crypto/secp256k1.js
@@ -54,5 +54,5 @@ export const create = ({ getPrivateHDKey }) => {
     return Object.freeze(signer)
   }
 
-  return Object.freeze({ ...createInstance(), createSigner, getCompressedPublicKey })
+  return Object.freeze({ ...createInstance(), createSigner, getUncompressedPublicKey })
 }

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -121,9 +121,15 @@ export class Keychain {
         throw new Error(`asset name ${keyId.assetName} has no legacyPrivToPub mapper`)
       }
     } else if (keyId.derivationAlgorithm !== 'SLIP10' && keyId.keyType === 'nacl') {
-      // SLIP10 already produces the correct public key for curve ed25119
+      // SLIP10 already produces the correct public key for curve ed25519
       // so we can safely skip using the privToPub mapper.
       publicKey = await sodium.privToPub(privateKey)
+    } else if (
+      keyId.derivationAlgorithm === 'BIP32' &&
+      keyId.keyType === 'secp256k1' &&
+      keyId.uncompressed
+    ) {
+      publicKey = await this.secp256k1.getUncompressedPublicKey(privateKey)
     }
 
     const { xpriv, xpub } = hdkey.toJSON()

--- a/features/keychain/package.json
+++ b/features/keychain/package.json
@@ -2,7 +2,7 @@
   "name": "@exodus/keychain",
   "version": "6.5.0",
   "description": "A module designed to work more securely with private key material",
-  "author": "Exodus Movement, Inc.",
+  "author": "Exodus Movement Inc.",
   "homepage": "https://github.com/ExodusMovement/exodus-oss/tree/master/features/keychain",
   "license": "MIT",
   "directories": {

--- a/libraries/key-identifier/src/key-identifier.js
+++ b/libraries/key-identifier/src/key-identifier.js
@@ -13,8 +13,9 @@ export default class KeyIdentifier {
   /** @type {DerivationPath} */
   #derivationPath
 
-  constructor({ derivationAlgorithm, derivationPath, assetName, keyType }) {
+  constructor({ derivationAlgorithm, derivationPath, assetName, keyType, uncompressed = false }) {
     assert(typeof derivationAlgorithm === 'string', 'derivationAlgorithm not a string')
+    assert(typeof uncompressed === 'boolean', 'uncompressed not a boolean')
     assert(
       SUPPORTED_KDFS.has(derivationAlgorithm),
       `${derivationAlgorithm} is not a valid derivationAlgorithm`
@@ -38,6 +39,7 @@ export default class KeyIdentifier {
     this.#derivationPath = isDerivationPath(derivationPath)
       ? derivationPath
       : DerivationPath.from(derivationPath)
+    this.uncompressed = uncompressed
 
     // Freeze the object on construction, disallow tampering with derivation path.
     // Ensures immutability of key identifiers passed to keychain.
@@ -65,6 +67,7 @@ export default class KeyIdentifier {
       assetName: this.assetName,
       keyType: this.keyType,
       derivationPath: this.derivationPath,
+      uncompressed: this.uncompressed,
     }
   }
 
@@ -83,7 +86,7 @@ export default class KeyIdentifier {
       return false
     }
 
-    return !['derivationAlgorithm', 'derivationPath', 'assetName', 'keyType'].some(
+    return !['derivationAlgorithm', 'derivationPath', 'assetName', 'keyType', 'uncompressed'].some(
       (fieldName) => keyIdA[fieldName] !== keyIdB[fieldName]
     )
   }


### PR DESCRIPTION
At least one assets requires the uncompressed secp256k1 public key to generate the address. Here I add somewhat generic support for handling a uncompressed public key.