### PR TITLE
feat: add common signature encoding

### DIFF
--- a/features/keychain/module/__tests__/ecdsa.test.js
+++ b/features/keychain/module/__tests__/ecdsa.test.js
@@ -103,6 +103,7 @@ describe('EcDSA Signer Signature Encoding', () => {
     binary:
       '9288b22525674d76b0d5b8b20f333d4de4f4f88340a7d0a4cadd54b719e6162df63e7591ce6b3bc0bf66fa2948d220e74ea2a74b63fc9dcb20e0f53191550b6700',
   }
+
   it('Default encoding', async () => {
     const signature = await keychain.secp256k1.signBuffer({ seedId, keyId, data })
     expect(signature instanceof Buffer).toBe(true)

--- a/features/keychain/module/crypto/secp256k1.js
+++ b/features/keychain/module/crypto/secp256k1.js
@@ -11,13 +11,11 @@ const isValidEcOptions = (ecOptions) =>
 const encodeSignature = ({ signature, enc }) => {
   if (enc === 'der') return Buffer.from(signature.toDER())
 
-  const sig = { ...signature }
+  if (enc === 'raw') return { ...signature }
 
-  if (enc === 'raw') return sig
-
-  const r = Buffer.from(sig.r.toArray('be', 32))
-  const s = Buffer.from(sig.s.toArray('be', 32))
-  return Buffer.concat([r, s, Buffer.from([sig.recoveryParam])])
+  const r = Buffer.from(signature.r.toArray('be', 32))
+  const s = Buffer.from(signature.s.toArray('be', 32))
+  return Buffer.concat([r, s, Buffer.from([signature.recoveryParam])])
 }
 
 export const create = ({ getPrivateHDKey }) => {

--- a/features/keychain/module/crypto/secp256k1.js
+++ b/features/keychain/module/crypto/secp256k1.js
@@ -8,6 +8,18 @@ import { tweakPrivateKey } from './tweak'
 const isValidEcOptions = (ecOptions) =>
   !ecOptions || Object.keys(ecOptions).every((key) => ['canonical'].includes(key))
 
+const encodeSignature = ({ signature, enc }) => {
+  if (enc === 'der') return Buffer.from(signature.toDER())
+
+  const sig = { ...signature }
+
+  if (enc === 'raw') return sig
+
+  const r = Buffer.from(sig.r.toArray('be', 32))
+  const s = Buffer.from(sig.s.toArray('be', 32))
+  return Buffer.concat([r, s, Buffer.from([sig.recoveryParam])])
+}
+
 export const create = ({ getPrivateHDKey }) => {
   const EC = elliptic.ec
   const curve = new EC('secp256k1')
@@ -18,11 +30,11 @@ export const create = ({ getPrivateHDKey }) => {
         keyId.keyType === 'secp256k1',
         `ECDSA signatures are not supported for ${keyId.keyType}`
       )
-      assert(['der', 'raw'].includes(enc), 'signBuffer: invalid enc')
+      assert(['der', 'raw', 'buff'].includes(enc), 'signBuffer: invalid enc')
       assert(isValidEcOptions(ecOptions), 'signBuffer: invalid EC option')
       const { privateKey } = getPrivateHDKey({ seedId, keyId })
       const signature = curve.sign(data, privateKey, pick(ecOptions, ['canonical']))
-      return enc === 'der' ? Buffer.from(signature.toDER()) : { ...signature }
+      return encodeSignature({ signature, enc })
     },
     signSchnorr: async ({ seedId, keyId, data, tweak, extraEntropy }) => {
       assert(

--- a/features/keychain/module/crypto/secp256k1.js
+++ b/features/keychain/module/crypto/secp256k1.js
@@ -30,7 +30,7 @@ export const create = ({ getPrivateHDKey }) => {
         keyId.keyType === 'secp256k1',
         `ECDSA signatures are not supported for ${keyId.keyType}`
       )
-      assert(['der', 'raw', 'buff'].includes(enc), 'signBuffer: invalid enc')
+      assert(['der', 'raw', 'binary'].includes(enc), 'signBuffer: invalid enc')
       assert(isValidEcOptions(ecOptions), 'signBuffer: invalid EC option')
       const { privateKey } = getPrivateHDKey({ seedId, keyId })
       const signature = curve.sign(data, privateKey, pick(ecOptions, ['canonical']))


### PR DESCRIPTION
This signature encoding seems to be popping up frequently. I'm wondering if we should include it here.

The binary encoding comes in handy so far for: filecoin, theta, tron, vechain, ...