### PR TITLE
feat: use `KeyIdentifier` as string tag

### DIFF
--- a/libraries/key-identifier/__tests__/key-identifier.test.js
+++ b/libraries/key-identifier/__tests__/key-identifier.test.js
@@ -116,6 +116,18 @@ describe('KeyIdentifier', () => {
     })
   })
 
+  describe('.toStringTag()', () => {
+    test('returns KeyIdentifier', () => {
+      const keyId = new KeyIdentifier({
+        derivationAlgorithm: 'BIP32',
+        assetName: 'ethereum',
+        derivationPath: "m/44'/60'/0'",
+      })
+
+      expect(keyId[Symbol.toStringTag]()).toBe('KeyIdentifier')
+    })
+  })
+
   describe('.compare()', () => {
     it('should return true when equal', () => {
       const keyIdA = new KeyIdentifier({

--- a/libraries/key-identifier/__tests__/key-identifier.test.js
+++ b/libraries/key-identifier/__tests__/key-identifier.test.js
@@ -124,7 +124,7 @@ describe('KeyIdentifier', () => {
         derivationPath: "m/44'/60'/0'",
       })
 
-      expect(keyId[Symbol.toStringTag]()).toBe('KeyIdentifier')
+      expect(keyId[Symbol.toStringTag]).toBe('KeyIdentifier')
     })
   })
 

--- a/libraries/key-identifier/__tests__/key-identifier.test.js
+++ b/libraries/key-identifier/__tests__/key-identifier.test.js
@@ -89,13 +89,12 @@ describe('KeyIdentifier', () => {
 
       const derived = keyId.derive([1, 5])
 
-      expect(derived).toEqual({
+      expect(derived.toJSON()).toEqual({
         derivationAlgorithm: 'BIP32',
         assetName: 'ethereum',
+        derivationPath: "m/44'/60'/0'/1/5",
         keyType: 'secp256k1',
       })
-
-      expect(derived.derivationPath).toBe("m/44'/60'/0'/1/5")
     })
   })
 

--- a/libraries/key-identifier/src/key-identifier.js
+++ b/libraries/key-identifier/src/key-identifier.js
@@ -59,7 +59,7 @@ export default class KeyIdentifier {
     return `${this.derivationPath} (${this.derivationAlgorithm})`
   }
 
-  [Symbol.toStringTag]() {
+  get [Symbol.toStringTag]() {
     return 'KeyIdentifier'
   }
 

--- a/libraries/key-identifier/src/key-identifier.js
+++ b/libraries/key-identifier/src/key-identifier.js
@@ -59,6 +59,10 @@ export default class KeyIdentifier {
     return `${this.derivationPath} (${this.derivationAlgorithm})`
   }
 
+  [Symbol.toStringTag]() {
+    return 'KeyIdentifier'
+  }
+
   toJSON() {
     return {
       derivationAlgorithm: this.derivationAlgorithm,


### PR DESCRIPTION
I was lead down a wrong path by a jest diff indicating that a key identifier I was dealing with was a pojo, even though it was a KeyIdentifier instance. This makes it clearer 