### PR TITLE
fix: ensure `derivationPath` is spreadable

### DIFF
--- a/libraries/key-identifier/__tests__/key-identifier.test.js
+++ b/libraries/key-identifier/__tests__/key-identifier.test.js
@@ -79,6 +79,31 @@ describe('KeyIdentifier', () => {
     expect(keyId.derivationPath).toBe("m/44'/60'/0'/0/0")
   })
 
+  test('spreads all properties', () => {
+    const properties = {
+      assetName: 'wayne-oin',
+      derivationAlgorithm: 'BIP32',
+      derivationPath: "m/44'/60'/0'",
+      keyType: 'secp256k1',
+    }
+
+    const keyId = new KeyIdentifier(properties)
+
+    expect({ ...keyId }).toEqual(properties)
+  })
+
+  test('cannot write derivationPath', () => {
+    const keyId = new KeyIdentifier({
+      derivationAlgorithm: 'BIP32',
+      assetName: 'ethereum',
+      derivationPath: ['m', "44'", "60'", "0'", '0', '0'],
+    })
+
+    expect(() => {
+      keyId.derivationPath = 'm/44/60/0/0/0'
+    }).toThrow()
+  })
+
   describe('.extend()', () => {
     test('extends derivation path', () => {
       const keyId = new KeyIdentifier({

--- a/libraries/key-identifier/__tests__/key-identifier.test.js
+++ b/libraries/key-identifier/__tests__/key-identifier.test.js
@@ -81,7 +81,7 @@ describe('KeyIdentifier', () => {
 
   test('spreads all properties', () => {
     const properties = {
-      assetName: 'wayne-oin',
+      assetName: 'wayne-coin',
       derivationAlgorithm: 'BIP32',
       derivationPath: "m/44'/60'/0'",
       keyType: 'secp256k1',

--- a/libraries/key-identifier/src/key-identifier.d.ts
+++ b/libraries/key-identifier/src/key-identifier.d.ts
@@ -18,7 +18,7 @@ export default class KeyIdentifier {
 
   constructor(params: ConstructorParams)
 
-  get derivationPath(): string
+  readonly derivationPath: string
 
   /**
    * Returns a new KeyIdentifier instance that has an updated derivation path extended with

--- a/libraries/key-identifier/src/key-identifier.js
+++ b/libraries/key-identifier/src/key-identifier.js
@@ -39,13 +39,14 @@ export default class KeyIdentifier {
       ? derivationPath
       : DerivationPath.from(derivationPath)
 
+    Object.defineProperty(this, 'derivationPath', {
+      value: this.#derivationPath.toString(),
+      enumerable: true,
+    })
+
     // Freeze the object on construction, disallow tampering with derivation path.
     // Ensures immutability of key identifiers passed to keychain.
     Object.freeze(this)
-  }
-
-  get derivationPath() {
-    return this.#derivationPath.toString()
   }
 
   derive(pathLike) {


### PR DESCRIPTION
The latest `KeyIdentifier` stores a derivation path by its raw indicies in an array had a getter to return the stringified derivation path. The getter is not necessary as the derivation path is immutable, meaning it is sufficient to set it once on construction. It also gets in the way e.g. when using jest matchers.