### PR TITLE
feat: allow unlocking private keys directly through seed ids

### DIFF
--- a/features/keychain/module/__tests__/lock-private-keys.test.js
+++ b/features/keychain/module/__tests__/lock-private-keys.test.js
@@ -187,4 +187,10 @@ describe('lockPrivateKeys', () => {
       /private keys are locked/
     )
   })
+
+  it('should allow providing seedIds directly', async () => {
+    const keychain = createKeychain({ seed })
+    keychain.lockPrivateKeys()
+    keychain.unlockPrivateKeys([seedId])
+  })
 })

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -22,6 +22,10 @@ const MAP_KDF = Object.freeze({
 
 export const MODULE_ID = 'keychain'
 
+function isArrayOfStrings(array) {
+  return Array.isArray(array) && array.every((element) => typeof element === 'string')
+}
+
 export class Keychain {
   #masters = Object.create(null)
   #legacyPrivToPub = null
@@ -62,7 +66,7 @@ export class Keychain {
       seeds?.length === Object.values(this.#masters).length,
       'must pass in same number of seeds'
     )
-    const seedIds = new Set(seeds.map((seed) => getSeedId(seed)))
+    const seedIds = new Set(isArrayOfStrings(seeds) ? seeds : seeds.map(getSeedId))
     for (const seedId of Object.keys(this.#masters)) {
       assert(seedIds.has(seedId), 'must pass in existing seed')
     }


### PR DESCRIPTION
## Description
Allow clients to feed the ids of the seeds directly instead of the seed when unlocking the private keys.

> [!IMPORTANT]
> I am not sure if this is completely safe, so please let me know if you think it is not.
>
> Even though it seems to simply set a boolean indicating whether the keys are locked or not, it might have other security impacts that Im not aware. 🤔 
>
> The worst scenario I can think of is someone being able to intercept the seed ids and then being able to call `unlockPrivateKeys` effectively unlocking the private keys, which AFAIK will simply prevent re-authentication per transaction...
>
> But as I said, I might be missing some important context here, so please let me know.

Towards: https://app.asana.com/0/1201782092493631/1207828730720173/f

## Context
In ME, with transaction verification enabled, it is impossible, to the extent of my knowledge, to unlock the private keys if the user has at least one extra seed.

This happens because:

- Keychain requires clients to provide the seeds when unlocking, it then derives the `seedIds` from them.
- In  the current implementation of Hydra wallet module, when retrieving the extra seeds it requires the [extra seeds passphrase](https://github.com/ExodusMovement/exodus-hydra/blob/4cf20f5bff98b68d587237f78e9d26df42ef65a7/features/wallet/module/wallet.js#L194)
- The passphrases however, [are stored in the keychain](https://github.com/ExodusMovement/exodus-hydra/blob/4cf20f5bff98b68d587237f78e9d26df42ef65a7/features/wallet/module/wallet.js#L106-L114) (it seems to use the private keys as passphrase)
- With private keys locked, it is not possible to retrieve the extra seed passphrase, therefore making it impossible to provide the keys to the keychain in the first bullet point 🤣 

We do already have the `seedIds` stored as keys of `seedMetadataAtom`, so we can simply forward it keychain instead of the seeds.

This is how I intend to use it: https://github.com/ExodusMovement/exodus-hydra/pull/7917