### PR TITLE
feat: implement seed-specific locked boolean flag

### DIFF
--- a/features/keychain/api/__tests__/index.test.js
+++ b/features/keychain/api/__tests__/index.test.js
@@ -4,6 +4,7 @@ import apiDefinition from '../index.js'
 import moduleDefinition from '../../module/index.js'
 import { getSeedId } from '../../module/crypto/seed-id.js'
 
+let keychain
 const mnemonic = 'cousin access oak tragic entire dynamic marine expand govern enjoy honey tissue'
 const otherMnemonic =
   'menu memory fury language physical wonder dog valid smart edge decrease worth'
@@ -53,7 +54,7 @@ describe('keychain api', () => {
   beforeEach(() => {
     jest.clearAllMocks()
 
-    const keychain = moduleDefinition.factory()
+    keychain = moduleDefinition.factory()
     api = apiDefinition.factory({ keychain }).keychain
     keychain.addSeed(seed)
     keychain.addSeed(otherSeed)
@@ -112,6 +113,29 @@ describe('keychain api', () => {
       ),
       xpriv: null,
       xpub: 'xpub6GZDo9NGhuCMi1tATK1mrkcCmsJkS7byjwVgjqp1pZxD1EQ4GMf9vD42r1jAM7teWuk63fPXDvWA8sBxrdVM9sEdhsbGH7jfCEgTg7mvVNh',
+    })
+  })
+
+  describe('arePrivateKeysLocked', () => {
+    test('returns false if no seeds are locked', async () => {
+      expect(api.arePrivateKeysLocked()).toBe(false)
+    })
+
+    test('returns true if all seeds are locked', async () => {
+      keychain.lockPrivateKeys()
+      expect(api.arePrivateKeysLocked([])).toBe(true)
+    })
+
+    test('returns true if some seeds are locked', async () => {
+      keychain.lockPrivateKeys()
+      keychain.unlockPrivateKeys([seed])
+      expect(api.arePrivateKeysLocked()).toBe(true)
+    })
+
+    test('returns false if targetted seed is unlocked', async () => {
+      keychain.lockPrivateKeys()
+      keychain.unlockPrivateKeys([seed])
+      expect(api.arePrivateKeysLocked([seed])).toBe(false)
     })
   })
 

--- a/features/keychain/api/index.d.ts
+++ b/features/keychain/api/index.d.ts
@@ -28,7 +28,7 @@ export interface KeychainApi {
   exportKey(params: KeySource): Promise<PublicKeys>
   exportKey(params: { exportPrivate: false } & KeySource): Promise<PublicKeys>
   exportKey(params: { exportPrivate: true } & KeySource): Promise<PublicKeys & PrivateKeys>
-  arePrivateKeysLocked(): Promise<boolean>
+  arePrivateKeysLocked(seeds: Buffer[]): boolean
   sodium: {
     signDetached(params: { data: Buffer } & KeySource): Promise<Buffer>
     getKeysFromSeed(

--- a/features/keychain/api/index.js
+++ b/features/keychain/api/index.js
@@ -2,7 +2,7 @@ const createKeychainApi = ({ keychain }) => {
   return {
     keychain: {
       exportKey: (...args) => keychain.exportKey(...args),
-      arePrivateKeysLocked: () => keychain.arePrivateKeysLocked(),
+      arePrivateKeysLocked: (seeds) => keychain.arePrivateKeysLocked(seeds),
       sodium: {
         signDetached: keychain.sodium.signDetached,
         getKeysFromSeed: (...args) =>

--- a/features/keychain/module/__tests__/lock-private-keys.test.js
+++ b/features/keychain/module/__tests__/lock-private-keys.test.js
@@ -132,11 +132,6 @@ describe('lockPrivateKeys', () => {
     ).rejects.toThrow(/private keys are locked/)
   })
 
-  it('should block unlock when already unlocked', async () => {
-    const keychain = createKeychain({ seed })
-    await expect(async () => keychain.unlockPrivateKeys([seed])).rejects.toThrow(/already unlocked/)
-  })
-
   it('should block unlock for wrong seed ids', async () => {
     const keychain = createKeychain({ seed })
     keychain.lockPrivateKeys()

--- a/features/keychain/module/__tests__/lock-private-keys.test.js
+++ b/features/keychain/module/__tests__/lock-private-keys.test.js
@@ -96,17 +96,6 @@ describe('lockPrivateKeys', () => {
     expect(Buffer.compare(publicKey, exportedKeys.publicKey)).toBe(0)
   })
 
-  it('should block unlock for wrong seeds length', async () => {
-    const keychain = createKeychain({ seed })
-    keychain.lockPrivateKeys()
-    await expect(async () => keychain.unlockPrivateKeys([])).rejects.toThrow(
-      /must pass in same number of seeds/
-    )
-    await expect(async () => keychain.unlockPrivateKeys([seed, seed])).rejects.toThrow(
-      /must pass in same number of seeds/
-    )
-  })
-
   it('should block unlock when already unlocked', async () => {
     const keychain = createKeychain({ seed })
     await expect(async () => keychain.unlockPrivateKeys([seed])).rejects.toThrow(/already unlocked/)
@@ -115,16 +104,32 @@ describe('lockPrivateKeys', () => {
   it('should block unlock for wrong seed ids', async () => {
     const keychain = createKeychain({ seed })
     keychain.lockPrivateKeys()
-    await expect(async () => keychain.unlockPrivateKeys([seed1])).rejects.toThrow(
+
+    const wrongSeed = mnemonicToSeed('menu'.repeat(12))
+    await expect(async () => keychain.unlockPrivateKeys([wrongSeed])).rejects.toThrow(
       /must pass in existing seed/
     )
 
     const keychain1 = createKeychain({ seed })
     keychain1.addSeed(seed1)
     keychain1.lockPrivateKeys()
-    await expect(async () => keychain1.unlockPrivateKeys([seed, seed])).rejects.toThrow(
+    await expect(async () => keychain1.unlockPrivateKeys([seed, wrongSeed])).rejects.toThrow(
       /must pass in existing seed/
     )
+  })
+
+  it('either unlock all provided seeds or none', async () => {
+    const keychain = createKeychain({ seed })
+
+    keychain.addSeed(seed1)
+    keychain.lockPrivateKeys()
+
+    const wrongSeed = mnemonicToSeed('menu'.repeat(12))
+    await expect(async () => keychain.unlockPrivateKeys([seed, wrongSeed])).rejects.toThrow(
+      /must pass in existing seed/
+    )
+
+    expect(keychain.arePrivateKeysLocked([seed])).toBe(true)
   })
 
   it('should block exportKey for private keys when locked', async () => {

--- a/features/keychain/module/crypto/seed-id.js
+++ b/features/keychain/module/crypto/seed-id.js
@@ -3,3 +3,9 @@ import { fromMasterSeed } from '@exodus/bip32'
 export const getSeedId = (seed) => fromMasterSeed(seed).identifier.toString('hex')
 
 export const getManySeedIds = (seeds) => seeds.map(getSeedId)
+
+export const getUniqueSeedIds = (seeds) => {
+  const seedIds = getManySeedIds(seeds)
+  const uniqueSeeIds = new Set(seedIds)
+  return [...uniqueSeeIds]
+}

--- a/features/keychain/module/crypto/seed-id.js
+++ b/features/keychain/module/crypto/seed-id.js
@@ -2,4 +2,4 @@ import { fromMasterSeed } from '@exodus/bip32'
 
 export const getSeedId = (seed) => fromMasterSeed(seed).identifier.toString('hex')
 
-export const getManySeedIds = (seeds) => new Set(seeds.map(getSeedId))
+export const getManySeedIds = (seeds) => seeds.map(getSeedId)

--- a/features/keychain/module/crypto/seed-id.js
+++ b/features/keychain/module/crypto/seed-id.js
@@ -1,3 +1,5 @@
 import { fromMasterSeed } from '@exodus/bip32'
 
 export const getSeedId = (seed) => fromMasterSeed(seed).identifier.toString('hex')
+
+export const getManySeedIds = (seeds) => new Set(seeds.map(getSeedId))

--- a/features/keychain/module/crypto/seed-id.js
+++ b/features/keychain/module/crypto/seed-id.js
@@ -6,6 +6,6 @@ export const getManySeedIds = (seeds) => seeds.map(getSeedId)
 
 export const getUniqueSeedIds = (seeds) => {
   const seedIds = getManySeedIds(seeds)
-  const uniqueSeeIds = new Set(seedIds)
-  return [...uniqueSeeIds]
+  const uniqueSeedIds = new Set(seedIds)
+  return [...uniqueSeedIds]
 }

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -86,7 +86,6 @@ export class Keychain {
       assert(hasSeed, 'must pass in existing seed')
     }
 
-    // Unlock seeds after verifying they exist
     for (const seedId of seedIds) {
       this.#seedLockStatus[seedId] = false
     }

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -50,13 +50,12 @@ export class Keychain {
   }
 
   #checkPrivateKeysLocked(seedIds) {
-    if (!seedIds?.length) {
+    if (!seedIds?.size) {
       return Object.values(this.#seedLockStatus).some((locked) => locked)
     }
 
-    const checkingSeeds = Object.entries(this.#seedLockStatus).filter(([seedId]) =>
-      seedIds.has(seedId)
-    )
+    const existingSeeds = Object.entries(this.#seedLockStatus)
+    const checkingSeeds = existingSeeds.filter(([seedId]) => seedIds.has(seedId))
 
     assert(checkingSeeds.length === seedIds.size, 'must pass in existing seeds')
     return checkingSeeds.some(([, locked]) => locked)

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -54,11 +54,10 @@ export class Keychain {
       return Object.values(this.#seedLockStatus).some(Boolean)
     }
 
-    const existingSeeds = Object.entries(this.#seedLockStatus)
-    const checkingSeeds = existingSeeds.filter(([seedId]) => seedIds.has(seedId))
-
-    assert(checkingSeeds.length === seedIds.size, 'must pass in existing seeds')
-    return checkingSeeds.some(([, locked]) => locked)
+    return seedIds.some((seedId) => { 
+      assert(Object.hasOwn(this.#seedLockStatus, seedId), `cannot check lock state for unknown seed "${seedId}"`)
+      return this.#seedLockStatus[seedId]
+    })
   }
 
   arePrivateKeysLocked(seeds = []) {

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -51,7 +51,7 @@ export class Keychain {
 
   #checkPrivateKeysLocked(seedIds) {
     if (!seedIds?.size) {
-      return Object.values(this.#seedLockStatus).some((locked) => locked)
+      return Object.values(this.#seedLockStatus).some(Boolean)
     }
 
     const existingSeeds = Object.entries(this.#seedLockStatus)

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -80,9 +80,9 @@ export class Keychain {
   unlockPrivateKeys(seeds = []) {
     const seedIds = getUniqueSeedIds(seeds)
 
-    const existingSeeds = Object.keys(this.#masters)
+    const existingSeedIds = Object.keys(this.#masters)
     for (const seedId of seedIds) {
-      const hasSeed = existingSeeds.includes(seedId)
+      const hasSeed = existingSeedIds.includes(seedId)
       assert(hasSeed, 'must pass in existing seed')
     }
 

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -111,7 +111,7 @@ export class Keychain {
 
   #getPrivateHDKey = ({ seedId, keyId, getPrivateHDKeySymbol }) => {
     if (getPrivateHDKeySymbol !== this.#getPrivateHDKeySymbol) {
-      this.#assertPrivateKeysUnlocked(new Set([seedId]))
+      this.#assertPrivateKeysUnlocked(seedId ? new Set([seedId]) : undefined)
     }
 
     throwIfInvalidKeyIdentifier(keyId)
@@ -126,7 +126,7 @@ export class Keychain {
 
   async exportKey({ seedId, keyId, exportPrivate }) {
     if (exportPrivate) {
-      this.#assertPrivateKeysUnlocked(new Set([seedId]))
+      this.#assertPrivateKeysUnlocked(seedId ? new Set([seedId]) : undefined)
     }
 
     keyId = new KeyIdentifier(keyId)
@@ -162,7 +162,7 @@ export class Keychain {
   }
 
   async signTx({ seedId, keyIds, signTxCallback, unsignedTx }) {
-    this.#assertPrivateKeysUnlocked(new Set([seedId]))
+    this.#assertPrivateKeysUnlocked(seedId ? new Set([seedId]) : undefined)
     assert(typeof signTxCallback === 'function', 'signTxCallback must be a function')
     const hdkeys = Object.fromEntries(
       keyIds.map((keyId) => {

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -101,6 +101,7 @@ export class Keychain {
 
     const seedId = getSeedId(seed)
     this.#masters[seedId] = masters
+    // manually unlock here since unlockPrivateKeys requires seed to already exist
     this.#seedLockStatus[seedId] = false
     return seedId
   }

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -75,7 +75,7 @@ export class Keychain {
     }, Object.create(null))
   }
 
-  unlockPrivateKeys(seeds) {
+  unlockPrivateKeys(seeds = []) {
     const seedIds = getManySeedIds(seeds)
     const locked = this.#checkPrivateKeysLocked(seedIds)
     assert(locked, 'already unlocked')

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -54,8 +54,11 @@ export class Keychain {
       return Object.values(this.#seedLockStatus).some(Boolean)
     }
 
-    return seedIds.some((seedId) => { 
-      assert(Object.hasOwn(this.#seedLockStatus, seedId), `cannot check lock state for unknown seed "${seedId}"`)
+    return seedIds.some((seedId) => {
+      assert(
+        Object.hasOwn(this.#seedLockStatus, seedId),
+        `cannot check lock state for unknown seed "${seedId}"`
+      )
       return this.#seedLockStatus[seedId]
     })
   }
@@ -75,8 +78,6 @@ export class Keychain {
 
   unlockPrivateKeys(seeds = []) {
     const seedIds = getManySeedIds(seeds)
-    const locked = this.#checkPrivateKeysLocked(seedIds)
-    assert(locked, 'already unlocked')
 
     const existingSeeds = Object.keys(this.#masters)
     for (const seedId of seedIds) {

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -127,8 +127,10 @@ export class Keychain {
   }
 
   async exportKey({ seedId, keyId, exportPrivate }) {
+    assert(typeof seedId === 'string', 'seedId must be a string')
+
     if (exportPrivate) {
-      this.#assertPrivateKeysUnlocked(seedId ? [seedId] : undefined)
+      this.#assertPrivateKeysUnlocked([seedId])
     }
 
     keyId = new KeyIdentifier(keyId)


### PR DESCRIPTION
## Description
As per our Zoom conversation, this PR implements a locked boolean flag per each seed individually, instead of using a single global flag for all seeds. 

This change allows for more granular control and flexibility in managing the locked status of each seed.

## Changes
- The locked/unlocked state is now managed as a dictionary of `seedId -> boolean`
- All `keychain` internal operations that need to check whether or not the private keys are unlocked and accept a `seedId` via parameter now consider only the locked state of that seed before proceeding
- When a seed id cannot be inferred, or was not provided, all keys are checked and the check fails if any of them are locked