### PR TITLE
feat: declare keychain definitions as public

### DIFF
--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -212,6 +212,7 @@ const createKeychain = (args = Object.create(null)) => new Keychain({ ...args })
 const keychainDefinition = {
   id: MODULE_ID,
   type: 'module',
+  public: true,
   factory: createKeychain,
   dependencies: ['legacyPrivToPub'],
 }

--- a/features/keychain/module/memoized-keychain.js
+++ b/features/keychain/module/memoized-keychain.js
@@ -59,6 +59,7 @@ class MemoizedKeychain extends Keychain {
 const memoizedKeychainDefinition = {
   id: 'keychain',
   type: 'module',
+  public: true,
   factory: (opts) => new MemoizedKeychain(opts),
   dependencies: ['storage', 'legacyPrivToPub'],
 }


### PR DESCRIPTION
In preparation for declaring registered dependencies private by default, this declares the keychain definitions as public. 