### PR TITLE
fix: `DerivationPath` predicate using `Symbol.toStringTag` getter

### DIFF
--- a/libraries/key-identifier/src/key-identifier.js
+++ b/libraries/key-identifier/src/key-identifier.js
@@ -8,7 +8,8 @@ const isDerivationPath = (derivationPath) =>
   typeof derivationPath === 'object' &&
   Symbol.toStringTag in derivationPath &&
   (derivationPath[Symbol.toStringTag] === 'DerivationPath' ||
-    derivationPath[Symbol.toStringTag]() === 'DerivationPath') // an older version of DerivationPath incorrectly used a method instead of a getter
+    (typeof derivationPath[Symbol.toStringTag] === 'function' &&
+      derivationPath[Symbol.toStringTag]() === 'DerivationPath')) // an older version of DerivationPath incorrectly used a method instead of a getter
 
 export default class KeyIdentifier {
   /** @type {DerivationPath} */

--- a/libraries/key-identifier/src/key-identifier.js
+++ b/libraries/key-identifier/src/key-identifier.js
@@ -7,7 +7,8 @@ const SUPPORTED_KEY_TYPES = new Set(['legacy', 'nacl', 'secp256k1'])
 const isDerivationPath = (derivationPath) =>
   typeof derivationPath === 'object' &&
   Symbol.toStringTag in derivationPath &&
-  derivationPath[Symbol.toStringTag]() === 'DerivationPath'
+  (derivationPath[Symbol.toStringTag] === 'DerivationPath' ||
+    derivationPath[Symbol.toStringTag]() === 'DerivationPath') // an older version of DerivationPath incorrectly used a method instead of a getter
 
 export default class KeyIdentifier {
   /** @type {DerivationPath} */


### PR DESCRIPTION
This fixes the `isDerivationPath` predicate by using the correct `Symbol.toStringTag` getter syntax. Keeping the previous check for backwards compat as well.