### PR TITLE
feat: expose `DerivationPath` instance via getPath

### DIFF
--- a/libraries/key-identifier/__tests__/key-identifier.test.js
+++ b/libraries/key-identifier/__tests__/key-identifier.test.js
@@ -1,5 +1,6 @@
 import { createKeyIdentifierForExodus } from '@exodus/key-ids'
 import KeyIdentifier from '../src/key-identifier.js'
+import { DerivationPath } from '@exodus/key-utils'
 
 describe('KeyIdentifier', () => {
   it('should fail on incorrect construction', () => {
@@ -102,6 +103,20 @@ describe('KeyIdentifier', () => {
     expect(() => {
       keyId.derivationPath = 'm/44/60/0/0/0'
     }).toThrow()
+  })
+
+  describe('getPath', () => {
+    test('returns derivation path', () => {
+      const keyId = new KeyIdentifier({
+        derivationAlgorithm: 'BIP32',
+        assetName: 'ethereum',
+        derivationPath: 'm/44/60/0/0/0',
+      })
+
+      const derivationPath = keyId.getPath()
+      expect(derivationPath).toBeInstanceOf(DerivationPath)
+      expect(derivationPath.toPathArray()).toEqual([44, 60, 0, 0, 0])
+    })
   })
 
   describe('.extend()', () => {

--- a/libraries/key-identifier/package.json
+++ b/libraries/key-identifier/package.json
@@ -26,7 +26,7 @@
     "todo:reenable:test:integration": "jest --testMatch='**/*.integration-test.js'"
   },
   "dependencies": {
-    "@exodus/key-utils": "^3.5.1",
+    "@exodus/key-utils": "^3.6.1",
     "minimalistic-assert": "^1.0.1"
   },
   "devDependencies": {

--- a/libraries/key-identifier/src/key-identifier.d.ts
+++ b/libraries/key-identifier/src/key-identifier.d.ts
@@ -1,3 +1,5 @@
+import type { DerivationPath } from '@exodus/key-utils'
+
 type PathIndex = number | string
 type KeyType = 'legacy' | 'nacl' | 'secp256k1'
 type DerivationAlgorithm = 'BIP32' | 'SLIP10'
@@ -25,6 +27,8 @@ export default class KeyIdentifier {
    * the path indices or partial derivation path supplied to this method
    */
   derive(pathLike: string | PathIndex[]): KeyIdentifier
+
+  getPath(): DerivationPath
 
   toJSON(): {
     assetName?: string

--- a/libraries/key-identifier/src/key-identifier.js
+++ b/libraries/key-identifier/src/key-identifier.js
@@ -58,6 +58,10 @@ export default class KeyIdentifier {
     })
   }
 
+  getPath() {
+    return this.#derivationPath
+  }
+
   toString() {
     return `${this.derivationPath} (${this.derivationAlgorithm})`
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1986,7 +1986,7 @@ __metadata:
   resolution: "@exodus/key-identifier@workspace:libraries/key-identifier"
   dependencies:
     "@exodus/key-ids": ^1.2.2
-    "@exodus/key-utils": ^3.5.1
+    "@exodus/key-utils": ^3.6.1
     "@exodus/keychain": "workspace:^"
     minimalistic-assert: ^1.0.1
   languageName: unknown
@@ -2032,6 +2032,18 @@ __metadata:
     bip32-path: ^0.4.2
     minimalistic-assert: ^1.0.1
   checksum: 491642eaf40c29805e149273a6853dae00036278af48f9afff8978776a212bebb1becbb22b38954a2d528c7a8a475116694029f5027932b4a488512cd28cd686
+  languageName: node
+  linkType: hard
+
+"@exodus/key-utils@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "@exodus/key-utils@npm:3.6.1"
+  dependencies:
+    "@exodus/bip32": ^2.1.0
+    "@exodus/hdkey": ^2.1.0-exodus.0
+    bip32-path: ^0.4.2
+    minimalistic-assert: ^1.0.1
+  checksum: d3e8e9832f28ea93188bde94a22be248d4a5bc46bc62dd54d79a783fbc7eb233dbbef3b8f6bf47539a9ac808adca9ea8cd5465a6307f1790fdefda0b9832d4da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add a way to access the `DerivationPath` instance used inside key identifier to store a derivation path. This allows for easier inspection/extraction of path indices required for certain use cases.