### PR TITLE
feat(keychain): implement removing specific seeds

### DIFF
--- a/features/keychain/api/index.d.ts
+++ b/features/keychain/api/index.d.ts
@@ -29,6 +29,7 @@ export interface KeychainApi {
   exportKey(params: { exportPrivate: false } & KeySource): Promise<PublicKeys>
   exportKey(params: { exportPrivate: true } & KeySource): Promise<PublicKeys & PrivateKeys>
   arePrivateKeysLocked(seeds: Buffer[]): boolean
+  removeManySeeds(seeds: Buffer[]): string[]
   sodium: {
     signDetached(params: { data: Buffer } & KeySource): Promise<Buffer>
     getKeysFromSeed(

--- a/features/keychain/api/index.d.ts
+++ b/features/keychain/api/index.d.ts
@@ -29,7 +29,7 @@ export interface KeychainApi {
   exportKey(params: { exportPrivate: false } & KeySource): Promise<PublicKeys>
   exportKey(params: { exportPrivate: true } & KeySource): Promise<PublicKeys & PrivateKeys>
   arePrivateKeysLocked(seeds: Buffer[]): boolean
-  removeManySeeds(seeds: Buffer[]): string[]
+  removeSeeds(seeds: Buffer[]): string[]
   sodium: {
     signDetached(params: { data: Buffer } & KeySource): Promise<Buffer>
     getKeysFromSeed(

--- a/features/keychain/module/__tests__/example.integration-test.js
+++ b/features/keychain/module/__tests__/example.integration-test.js
@@ -68,7 +68,7 @@ test('lock', async () => {
   await expect(keychain.exportKey(solanaKeyId)).rejects.toThrow()
 })
 
-describe('removeManySeeds', () => {
+describe('removeSeeds', () => {
   const extraSeed = mnemonicToSeed('menu'.repeat(12))
   const extraSeedId = getSeedId(extraSeed)
 
@@ -80,7 +80,7 @@ describe('removeManySeeds', () => {
 
     keychain.addSeed(seed)
     keychain.addSeed(extraSeed)
-    keychain.removeManySeeds([extraSeed])
+    keychain.removeSeeds([extraSeed])
 
     await expect(keychain.exportKey(seed)).resolves.toBe([extraSeedId])
     await expect(keychain.exportKey(extraSeed)).rejects.toThrow()

--- a/features/keychain/module/__tests__/example.integration-test.js
+++ b/features/keychain/module/__tests__/example.integration-test.js
@@ -68,6 +68,25 @@ test('lock', async () => {
   await expect(keychain.exportKey(solanaKeyId)).rejects.toThrow()
 })
 
+describe('removeManySeeds', () => {
+  const extraSeed = mnemonicToSeed('menu'.repeat(12))
+  const extraSeedId = getSeedId(extraSeed)
+
+  it('removes seeds from the keychain', async () => {
+    const keychain = keychainDefinition.factory({
+      logger: console,
+      legacyPrivToPub: Object.create(null),
+    })
+
+    keychain.addSeed(seed)
+    keychain.addSeed(extraSeed)
+    keychain.removeManySeeds([extraSeed])
+
+    await expect(keychain.exportKey(seed)).resolves.toBe([extraSeedId])
+    await expect(keychain.exportKey(extraSeed)).rejects.toThrow()
+  })
+})
+
 test('signTx', async () => {
   const unsignedTx = await createUnsignedSolanaTx({
     asset,

--- a/features/keychain/module/__tests__/example.integration-test.js
+++ b/features/keychain/module/__tests__/example.integration-test.js
@@ -85,6 +85,21 @@ describe('removeSeeds', () => {
     await expect(keychain.exportKey(seed)).resolves.toBe([extraSeedId])
     await expect(keychain.exportKey(extraSeed)).rejects.toThrow()
   })
+
+  it('return the ids of the removed seeds only', async () => {
+    {
+      const keychain = keychainDefinition.factory({
+        logger: console,
+        legacyPrivToPub: Object.create(null),
+      })
+
+      keychain.addSeed(seed)
+      keychain.addSeed(extraSeed)
+      keychain.removeSeeds([extraSeed, 'missingSeed'])
+
+      await expect(keychain.exportKey(seed)).resolves.toBe([extraSeedId])
+    }
+  })
 })
 
 test('signTx', async () => {

--- a/features/keychain/module/__tests__/example.integration-test.js
+++ b/features/keychain/module/__tests__/example.integration-test.js
@@ -87,18 +87,16 @@ describe('removeSeeds', () => {
   })
 
   it('return the ids of the removed seeds only', async () => {
-    {
-      const keychain = keychainDefinition.factory({
-        logger: console,
-        legacyPrivToPub: Object.create(null),
-      })
+    const keychain = keychainDefinition.factory({
+      logger: console,
+      legacyPrivToPub: Object.create(null),
+    })
 
-      keychain.addSeed(seed)
-      keychain.addSeed(extraSeed)
-      keychain.removeSeeds([extraSeed, 'missingSeed'])
+    keychain.addSeed(seed)
+    keychain.addSeed(extraSeed)
+    keychain.removeSeeds([extraSeed, 'missingSeed'])
 
-      await expect(keychain.exportKey(seed)).resolves.toBe([extraSeedId])
-    }
+    await expect(keychain.exportKey(seed)).resolves.toBe([extraSeedId])
   })
 })
 

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -113,12 +113,15 @@ export class Keychain {
 
   removeSeeds(seeds = []) {
     const seedIds = getUniqueSeedIds(seeds)
-    for (const id of seedIds) {
+    const existingSeedIds = Object.keys(this.#masters)
+    const seedIdsToRemove = seedIds.filter((seedId) => existingSeedIds.includes(seedId))
+
+    for (const id of seedIdsToRemove) {
       delete this.#masters[id]
       delete this.#seedLockStatus[id]
     }
 
-    return seedIds
+    return seedIdsToRemove
   }
 
   #getPrivateHDKey = ({ seedId, keyId, getPrivateHDKeySymbol }) => {

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -111,7 +111,7 @@ export class Keychain {
     this.#seedLockStatus = Object.create(null)
   }
 
-  removeManySeeds(seeds = []) {
+  removeSeeds(seeds = []) {
     const seedIds = getUniqueSeedIds(seeds)
     for (const id of seedIds) {
       delete this.#masters[id]

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -113,7 +113,9 @@ export class Keychain {
 
   removeSeeds(seeds = []) {
     const seedIds = getUniqueSeedIds(seeds)
-    const existingSeedIds = Object.keys(this.#masters)
+    const existingSeedIds = [
+      ...new Set([...Object.keys(this.#masters), ...Object.keys(this.#seedLockStatus)]),
+    ]
     const seedIdsToRemove = seedIds.filter((seedId) => existingSeedIds.includes(seedId))
 
     for (const id of seedIdsToRemove) {

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -111,6 +111,16 @@ export class Keychain {
     this.#seedLockStatus = Object.create(null)
   }
 
+  removeManySeeds(seeds = []) {
+    const seedIds = getUniqueSeedIds(seeds)
+    for (const id of seedIds) {
+      delete this.#masters[id]
+      delete this.#seedLockStatus[id]
+    }
+
+    return seedIds
+  }
+
   #getPrivateHDKey = ({ seedId, keyId, getPrivateHDKeySymbol }) => {
     if (getPrivateHDKeySymbol !== this.#getPrivateHDKeySymbol) {
       this.#assertPrivateKeysUnlocked(seedId ? [seedId] : undefined)

--- a/features/keychain/module/keychain.js
+++ b/features/keychain/module/keychain.js
@@ -113,10 +113,11 @@ export class Keychain {
 
   removeSeeds(seeds = []) {
     const seedIds = getUniqueSeedIds(seeds)
-    const existingSeedIds = [
-      ...new Set([...Object.keys(this.#masters), ...Object.keys(this.#seedLockStatus)]),
-    ]
-    const seedIdsToRemove = seedIds.filter((seedId) => existingSeedIds.includes(seedId))
+    const existingSeedIds = new Set([
+      ...Object.keys(this.#masters),
+      ...Object.keys(this.#seedLockStatus),
+    ])
+    const seedIdsToRemove = seedIds.filter((seedId) => existingSeedIds.has(seedId))
 
     for (const id of seedIdsToRemove) {
       delete this.#masters[id]


### PR DESCRIPTION
## Description
With multi-seed, and now with the lock status of the seeds being managed individually, we need a way to remove only specific seeds from the keychain when those are deleted, this PR implements that.