### PR TITLE
feat: allow exporting sodium private keys

### DIFF
--- a/features/keychain/module/__tests__/sodium.test.js
+++ b/features/keychain/module/__tests__/sodium.test.js
@@ -34,6 +34,34 @@ describe('libsodium', () => {
     expect(Buffer.compare(publicKey, exportedKeys.publicKey)).toBe(0)
   })
 
+  it('should not export private keys by default', async () => {
+    const keychain = createKeychain({ seed })
+
+    const {
+      sign: { privateKey: signPrivateKey },
+      box: { privateKey: boxPrivateKey },
+    } = await keychain.sodium.getSodiumKeysFromSeed({ seedId, keyId: ALICE_KEY })
+
+    expect(signPrivateKey).toBeNull()
+    expect(boxPrivateKey).toBeNull()
+  })
+
+  it('should allow exporting private keys', async () => {
+    const keychain = createKeychain({ seed })
+
+    const {
+      sign: { privateKey: signPrivateKey },
+      box: { privateKey: boxPrivateKey },
+    } = await keychain.sodium.getSodiumKeysFromSeed({
+      seedId,
+      keyId: ALICE_KEY,
+      exportPrivate: true,
+    })
+
+    expect(signPrivateKey).toBeDefined()
+    expect(boxPrivateKey).toBeDefined()
+  })
+
   it('should have sign keys compatibility with SLIP10 (using sodium instance)', async () => {
     const keychain = createKeychain({ seed })
     const exportedKeys = await keychain.exportKey({ seedId, keyId: ALICE_KEY })

--- a/features/keychain/module/crypto/sodium.js
+++ b/features/keychain/module/crypto/sodium.js
@@ -7,22 +7,29 @@ const cloneBuffer = (buf) => {
   return newBuffer
 }
 
+const cloneKeypair = ({ keys, exportPrivate }) => {
+  return {
+    publicKey: cloneBuffer(keys.publicKey),
+    privateKey: exportPrivate ? cloneBuffer(keys.privateKey) : null,
+  }
+}
+
 export const create = ({ getPrivateHDKey }) => {
   // Sodium encryptor caches the private key and the return value holds
   // not refences to keychain internals, allowing the seed to be safely
   // garbage collected, clearing it from memory.
-  const getSodiumKeysFromIdentifier = async ({ seedId, keyId }) => {
-    const { privateKey: sodiumSeed } = getPrivateHDKey({ seedId, keyId })
+  const getSodiumKeysFromIdentifier = async ({ seedId, keyId, exportPrivate }) => {
+    const { privateKey: sodiumSeed } = getPrivateHDKey({ seedId, keyId, exportPrivate })
     return sodium.getSodiumKeysFromSeed(sodiumSeed)
   }
 
   const createInstance = () => ({
-    getSodiumKeysFromSeed: async ({ seedId, keyId }) => {
+    getSodiumKeysFromSeed: async ({ seedId, keyId, exportPrivate }) => {
       const { box, sign, secret } = await getSodiumKeysFromIdentifier({ seedId, keyId })
 
       return {
-        box: { publicKey: cloneBuffer(box.publicKey) },
-        sign: { publicKey: cloneBuffer(sign.publicKey) },
+        box: cloneKeypair({ keys: box, exportPrivate }),
+        sign: cloneKeypair({ keys: sign, exportPrivate }),
         secret: cloneBuffer(secret),
       }
     },


### PR DESCRIPTION
## Description

Adds a `exportPrivate` parameter to the `keychain.sodium.getSodiumKeysFromSeed` method, similar to what we have `keychain.exportKey`, allowing to export the sodium private keys when that flag is set to `true`.