### PR TITLE
fix(keychain)!: only export secret if "exportPrivate" flag is set

### DIFF
--- a/features/keychain/module/__tests__/sodium.test.js
+++ b/features/keychain/module/__tests__/sodium.test.js
@@ -40,10 +40,12 @@ describe('libsodium', () => {
     const {
       sign: { privateKey: signPrivateKey },
       box: { privateKey: boxPrivateKey },
+      secret,
     } = await keychain.sodium.getSodiumKeysFromSeed({ seedId, keyId: ALICE_KEY })
 
     expect(signPrivateKey).toBeNull()
     expect(boxPrivateKey).toBeNull()
+    expect(secret).toBeNull()
   })
 
   it('should allow exporting private keys', async () => {
@@ -52,6 +54,7 @@ describe('libsodium', () => {
     const {
       sign: { privateKey: signPrivateKey },
       box: { privateKey: boxPrivateKey },
+      secret,
     } = await keychain.sodium.getSodiumKeysFromSeed({
       seedId,
       keyId: ALICE_KEY,
@@ -60,6 +63,7 @@ describe('libsodium', () => {
 
     expect(signPrivateKey).toBeDefined()
     expect(boxPrivateKey).toBeDefined()
+    expect(secret).toBeDefined()
   })
 
   it('should have sign keys compatibility with SLIP10 (using sodium instance)', async () => {

--- a/features/keychain/module/crypto/sodium.js
+++ b/features/keychain/module/crypto/sodium.js
@@ -30,7 +30,7 @@ export const create = ({ getPrivateHDKey }) => {
       return {
         box: cloneKeypair({ keys: box, exportPrivate }),
         sign: cloneKeypair({ keys: sign, exportPrivate }),
-        secret: cloneBuffer(secret),
+        secret: exportPrivate ? cloneBuffer(secret) : null,
       }
     },
     sign: async ({ seedId, keyId, data }) => {


### PR DESCRIPTION
## Description
Updates the `keychain` module so that `keychain.sodium.getSodiumKeysFromSeed` only returns the `secret` key when `exportSecret` is set.

## Context
The `secret` key holds the symmetric-key encryption key used in `libsodium` to both encrypt and decrypt messages, therefore its very sensitive data and shouldn't be exposed unless in very specific situations.

Closes: #136 