### PR TITLE
refactor(keychain): drop unused getPrivateHDKey "exportPrivate" param

### DIFF
--- a/features/keychain/module/crypto/sodium.js
+++ b/features/keychain/module/crypto/sodium.js
@@ -18,8 +18,8 @@ export const create = ({ getPrivateHDKey }) => {
   // Sodium encryptor caches the private key and the return value holds
   // not refences to keychain internals, allowing the seed to be safely
   // garbage collected, clearing it from memory.
-  const getSodiumKeysFromIdentifier = async ({ seedId, keyId, exportPrivate }) => {
-    const { privateKey: sodiumSeed } = getPrivateHDKey({ seedId, keyId, exportPrivate })
+  const getSodiumKeysFromIdentifier = async ({ seedId, keyId }) => {
+    const { privateKey: sodiumSeed } = getPrivateHDKey({ seedId, keyId })
     return sodium.getSodiumKeysFromSeed(sodiumSeed)
   }
 


### PR DESCRIPTION
## Description
As noticed by @633kh4ck in [this comment](https://github.com/ExodusMovement/exodus-mobile/pull/21615#issuecomment-2348985772), the `exportPrivate` parameter is unused by `getPrivateHDKey`, so not really necessary.

The presence of this parameter also gives a false sense of security as devs looking at the current usage, since we don't have type validations when consuming that method, might assume that omitting that flag would avoid the private keys from being returned, which is not the case.