### PR TITLE
feat: expose sodium encryption through API

### DIFF
--- a/features/keychain/api/__tests__/index.test.js
+++ b/features/keychain/api/__tests__/index.test.js
@@ -148,6 +148,16 @@ describe('keychain api', () => {
       keyType: 'secp256k1',
     })
 
+    test('should encrypt and decrypt data', async () => {
+      const data = Buffer.from("Batman's is Harvey Dent")
+      const encrypted = await api.sodium.encryptSecretBox({ seedId, keyId, data })
+
+      expect(encrypted).toBeInstanceOf(Buffer)
+
+      const decrypted = await api.sodium.decryptSecretBox({ seedId, keyId, data: encrypted })
+      expect(data.compare(decrypted)).toBe(0)
+    })
+
     test('signDetached signs data', async () => {
       const data = Buffer.from("Batman's identity was revealed as Harvey Dent")
       const signature = await api.sodium.signDetached({ seedId, keyId, data })

--- a/features/keychain/api/index.d.ts
+++ b/features/keychain/api/index.d.ts
@@ -35,6 +35,8 @@ export interface KeychainApi {
     getKeysFromSeed(
       params: KeySource
     ): Promise<{ box: { publicKey: Buffer }; sign: { publicKey: Buffer } }>
+    encryptSecretBox(params: { data: Buffer } & KeySource): Promise<Buffer>
+    decryptSecretBox(params: { data: Buffer } & KeySource): Promise<Buffer>
   }
   ed25519: {
     signBuffer(params: { data: Buffer } & KeySource): Promise<Buffer>

--- a/features/keychain/api/index.js
+++ b/features/keychain/api/index.js
@@ -5,6 +5,8 @@ const createKeychainApi = ({ keychain }) => {
       arePrivateKeysLocked: (seeds) => keychain.arePrivateKeysLocked(seeds),
       sodium: {
         signDetached: keychain.sodium.signDetached,
+        encryptSecretBox: keychain.sodium.encryptSecretBox,
+        decryptSecretBox: keychain.sodium.decryptSecretBox,
         getKeysFromSeed: (...args) =>
           keychain.sodium.getSodiumKeysFromSeed(...args).then(({ box, sign }) => ({ box, sign })),
       },


### PR DESCRIPTION
Expose `encryptSecretBox ` and `decryptSecretBox` through the keychain API