### PR TITLE
feat: switch to exodus/crypto for schnorr signatures

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ const shared = {
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
 const isModule = pkg.type === 'module'
 
-const sourceExts = ['js', 'json', 'ts', 'tsx', 'android.js', 'ios.js']
+const sourceExts = ['js', 'mjs', 'cjs', 'json', 'ts', 'tsx', 'android.js', 'ios.js']
 const esmConfigs = isModule
   ? ['plugin:@exodus/require-extensions/recommended', 'plugin:@exodus/hydra/esm']
   : []

--- a/features/keychain/module/__tests__/schnorr.test.js
+++ b/features/keychain/module/__tests__/schnorr.test.js
@@ -1,24 +1,8 @@
 import { utils } from '@noble/secp256k1'
-import ecc from '@exodus/bitcoinerlab-secp256k1'
+import { publicKeyToX } from '@exodus/crypto/secp256k1'
 
 import { create } from '../crypto/secp256k1.js'
 import KeyIdentifier from '@exodus/key-identifier'
-
-import { createHmac, createHash } from 'crypto'
-
-if (!utils.hmacSha256Sync) {
-  utils.hmacSha256Sync = (k, ...m) =>
-    createHmac('sha256', k)
-      .update(utils.concatBytes(...m))
-      .digest()
-}
-
-if (!utils.sha256Sync) {
-  utils.sha256Sync = (...m) =>
-    createHash('sha256')
-      .update(utils.concatBytes(...m))
-      .digest()
-}
 
 const fixtures = [
   {
@@ -44,7 +28,7 @@ const fixtures = [
 ]
 
 const tapTweakHash = (publicKey, h) => {
-  const xOnlyPoint = ecc.xOnlyPointFromPoint(publicKey)
+  const xOnlyPoint = publicKeyToX({ publicKey })
   const hash = utils.taggedHashSync('TapTweak', Buffer.concat(h ? [xOnlyPoint, h] : [xOnlyPoint]))
   return Buffer.from(hash)
 }

--- a/features/keychain/module/crypto/secp256k1.js
+++ b/features/keychain/module/crypto/secp256k1.js
@@ -1,7 +1,7 @@
 import assert from 'minimalistic-assert'
+import * as secp256k1 from '@exodus/crypto/secp256k1'
 import elliptic from '@exodus/elliptic'
 import { mapValues } from '@exodus/basic-utils'
-import ecc from '@exodus/bitcoinerlab-secp256k1'
 
 import { tweakPrivateKey } from './tweak.js'
 
@@ -41,7 +41,7 @@ export const create = ({ getPrivateHDKey }) => {
       )
       const hdkey = getPrivateHDKey({ seedId, keyId })
       const privateKey = tweak ? tweakPrivateKey({ hdkey, tweak }) : hdkey.privateKey
-      return ecc.signSchnorr(data, privateKey, extraEntropy)
+      return secp256k1.schnorrSign({ data, privateKey, extraEntropy })
     },
   })
 

--- a/features/keychain/module/crypto/tweak.js
+++ b/features/keychain/module/crypto/tweak.js
@@ -1,13 +1,16 @@
 import assert from 'minimalistic-assert'
-import ecc from '@exodus/bitcoinerlab-secp256k1'
+import * as secp256k1 from '@exodus/crypto/secp256k1'
 
 export const tweakPrivateKey = ({ hdkey, tweak }) => {
   const { privateKey, publicKey } = hdkey
-  assert(ecc.isPrivate(privateKey), 'tweakPrivateKey: expected valid private key')
-  assert(ecc.isPointCompressed(publicKey), 'tweakPrivateKey: expected compressed public key')
+  assert(secp256k1.privateKeyIsValid({ privateKey }), 'tweakPrivateKey: expected valid private key')
+  assert(
+    secp256k1.publicKeyIsValid({ publicKey, compressed: true }),
+    'tweakPrivateKey: expected compressed public key'
+  )
 
-  let tweakedPrivateKey = publicKey[0] === 3 ? ecc.privateNegate(privateKey) : privateKey
-  tweakedPrivateKey = ecc.privateAdd(tweakedPrivateKey, tweak)
+  const tweakedPrivateKey =
+    publicKey[0] === 3 ? secp256k1.privateKeyTweakNegate({ privateKey }) : privateKey
 
-  return Buffer.from(tweakedPrivateKey)
+  return secp256k1.privateKeyTweakAdd({ privateKey: tweakedPrivateKey, tweak, format: 'buffer' })
 }

--- a/features/keychain/package.json
+++ b/features/keychain/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@exodus/basic-utils": "^2.0.0",
     "@exodus/bip32": "^2.1.0",
-    "@exodus/bitcoinerlab-secp256k1": "^1.0.5-exodus.1",
+    "@exodus/crypto": "^1.0.0-rc.13",
     "@exodus/elliptic": "^6.5.4-precomputed",
     "@exodus/key-identifier": "^1.1.2",
     "@exodus/key-utils": "^3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2338,13 +2338,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@exodus/bitcoinerlab-secp256k1@npm:^1.0.5-exodus.1":
-  version: 1.0.5-exodus.1
-  resolution: "@exodus/bitcoinerlab-secp256k1@npm:1.0.5-exodus.1"
+"@exodus/crypto@npm:^1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@exodus/crypto@npm:1.0.0-rc.13"
   dependencies:
-    "@noble/hashes": ^1.1.5
+    "@noble/hashes": ^1.3.3
     "@noble/secp256k1": ^1.7.1
-  checksum: b9ba53bdf8eee1af328633fe772f592d0dbbd2a6bc8a7c5518028133d7a26a2f377daa8551ddc27dd1932c808ecac6baff153aec655fc98f0153b4aa707f02e3
+  checksum: 06b3e73a745ed6766471052bb5571d9bf2d3c4cbabd9c21fa2bab0f1ffba63f8b41e84660cda22991ba8d90e516114dc9515da220d4ff12e5c12e5c03bd2e6d1
   languageName: node
   linkType: hard
 
@@ -2536,7 +2536,7 @@ __metadata:
   dependencies:
     "@exodus/basic-utils": ^2.0.0
     "@exodus/bip32": ^2.1.0
-    "@exodus/bitcoinerlab-secp256k1": ^1.0.5-exodus.1
+    "@exodus/crypto": ^1.0.0-rc.13
     "@exodus/elliptic": ^6.5.4-precomputed
     "@exodus/key-identifier": ^1.1.2
     "@exodus/key-ids": ^1.0.0
@@ -3196,10 +3196,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^1.1.5":
-  version: 1.4.0
-  resolution: "@noble/hashes@npm:1.4.0"
-  checksum: 8ba816ae26c90764b8c42493eea383716396096c5f7ba6bea559993194f49d80a73c081f315f4c367e51bd2d5891700bcdfa816b421d24ab45b41cb03e4f3342
+"@noble/hashes@npm:^1.3.3":
+  version: 1.5.0
+  resolution: "@noble/hashes@npm:1.5.0"
+  checksum: 9cc031d5c888c455bfeef76af649b87f75380a4511405baea633c1e4912fd84aff7b61e99716f0231d244c9cfeda1fafd7d718963e6a0c674ed705e9b1b4f76b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The same underlying `noble` lib, but cleaner API + `utils.hmacSha256Sync` / `utils.sha256Sync` initialized
Also, we can use async for native sha256