### PR TITLE
feat: add `sodium.getKeysFromSeed`

### DIFF
--- a/features/keychain/api/index.js
+++ b/features/keychain/api/index.js
@@ -8,7 +8,7 @@ const createKeychainApi = ({ keychain }) => {
         encryptSecretBox: keychain.sodium.encryptSecretBox,
         decryptSecretBox: keychain.sodium.decryptSecretBox,
         getKeysFromSeed: (...args) =>
-          keychain.sodium.getSodiumKeysFromSeed(...args).then(({ box, sign }) => ({ box, sign })),
+          keychain.sodium.getKeysFromSeed(...args).then(({ box, sign }) => ({ box, sign })),
       },
       ed25519: {
         signBuffer: keychain.ed25519.signBuffer,

--- a/features/keychain/module/crypto/sodium.js
+++ b/features/keychain/module/crypto/sodium.js
@@ -23,16 +23,20 @@ export const create = ({ getPrivateHDKey }) => {
     return sodium.getSodiumKeysFromSeed(sodiumSeed)
   }
 
-  const createInstance = () => ({
-    getSodiumKeysFromSeed: async ({ seedId, keyId, exportPrivate }) => {
-      const { box, sign, secret } = await getSodiumKeysFromIdentifier({ seedId, keyId })
+  const getKeysFromSeed = async ({ seedId, keyId, exportPrivate }) => {
+    const { box, sign, secret } = await getSodiumKeysFromIdentifier({ seedId, keyId })
 
-      return {
-        box: cloneKeypair({ keys: box, exportPrivate }),
-        sign: cloneKeypair({ keys: sign, exportPrivate }),
-        secret: exportPrivate ? cloneBuffer(secret) : null,
-      }
-    },
+    return {
+      box: cloneKeypair({ keys: box, exportPrivate }),
+      sign: cloneKeypair({ keys: sign, exportPrivate }),
+      secret: exportPrivate ? cloneBuffer(secret) : null,
+    }
+  }
+
+  const createInstance = () => ({
+    getKeysFromSeed,
+    /** @deprecated use getKeysFromSeed instead */
+    getSodiumKeysFromSeed: getKeysFromSeed,
     sign: async ({ seedId, keyId, data }) => {
       const { sign } = await getSodiumKeysFromIdentifier({ seedId, keyId })
       return sodium.sign({ message: data, privateKey: sign.privateKey })


### PR DESCRIPTION
This adds `sodium.getKeysFromSeed` for the keychain module, so that api and module have the same interface. Below is what we use in the api:

https://github.com/ExodusMovement/exodus-oss/blob/c1dd7e18a51e425440be3fdda60b3d9e0e3afca0/features/keychain/api/index.d.ts#L24-L26



This is relevant for the wallet process. Keeps `getSodiumKeysFromSeed` for backwards compat and deprecates it.