### PR TITLE
feat: use exodus/crypto instead of sodium where possible

### DIFF
--- a/features/keychain/module/crypto/ed25519.js
+++ b/features/keychain/module/crypto/ed25519.js
@@ -1,18 +1,13 @@
-import sodium from '@exodus/sodium-crypto'
+import { signDetached } from '@exodus/crypto/curve25519'
 import { mapValues } from '@exodus/basic-utils'
 import assert from 'minimalistic-assert'
 
 export const create = ({ getPrivateHDKey }) => {
-  const getSodiumKeysFromIdentifier = async ({ seedId, keyId }) => {
-    const { privateKey: sodiumSeed } = getPrivateHDKey({ seedId, keyId })
-    return sodium.getSodiumKeysFromSeed(sodiumSeed)
-  }
-
   const createInstance = () => ({
     signBuffer: async ({ seedId, keyId, data }) => {
       assert(keyId.keyType === 'nacl', `ED25519 signatures are not supported for ${keyId.keyType}`)
-      const { sign } = await getSodiumKeysFromIdentifier({ seedId, keyId })
-      return sodium.signDetached({ message: data, privateKey: sign.privateKey })
+      const { privateKey } = getPrivateHDKey({ seedId, keyId })
+      return signDetached({ message: data, privateKey, format: 'buffer' })
     },
   })
 

--- a/features/keychain/module/crypto/sodium.js
+++ b/features/keychain/module/crypto/sodium.js
@@ -1,6 +1,7 @@
 import sodium from '@exodus/sodium-crypto'
 import { mapValues } from '@exodus/basic-utils'
 import * as curve25519 from '@exodus/crypto/curve25519'
+import { getSodiumKeysFromSeed } from '@exodus/crypto/sodium'
 
 const cloneBuffer = (buf) => {
   const newBuffer = Buffer.alloc(buf.length)
@@ -21,7 +22,7 @@ export const create = ({ getPrivateHDKey }) => {
   // garbage collected, clearing it from memory.
   const getSodiumKeysFromIdentifier = async ({ seedId, keyId }) => {
     const { privateKey: sodiumSeed } = getPrivateHDKey({ seedId, keyId })
-    return sodium.getSodiumKeysFromSeed(sodiumSeed)
+    return getSodiumKeysFromSeed(sodiumSeed)
   }
 
   const getKeysFromSeed = async ({ seedId, keyId, exportPrivate }) => {

--- a/features/keychain/module/crypto/sodium.js
+++ b/features/keychain/module/crypto/sodium.js
@@ -1,5 +1,6 @@
 import sodium from '@exodus/sodium-crypto'
 import { mapValues } from '@exodus/basic-utils'
+import * as curve25519 from '@exodus/crypto/curve25519'
 
 const cloneBuffer = (buf) => {
   const newBuffer = Buffer.alloc(buf.length)
@@ -38,20 +39,20 @@ export const create = ({ getPrivateHDKey }) => {
     /** @deprecated use getKeysFromSeed instead */
     getSodiumKeysFromSeed: getKeysFromSeed,
     sign: async ({ seedId, keyId, data }) => {
-      const { sign } = await getSodiumKeysFromIdentifier({ seedId, keyId })
-      return sodium.sign({ message: data, privateKey: sign.privateKey })
+      const { privateKey } = getPrivateHDKey({ seedId, keyId })
+      return curve25519.signAttached({ message: data, privateKey, format: 'buffer' })
     },
     signOpen: async ({ seedId, keyId, data }) => {
-      const { sign } = await getSodiumKeysFromIdentifier({ seedId, keyId })
-      return sodium.signOpen({ signed: data, publicKey: sign.publicKey })
+      const { publicKey } = getPrivateHDKey({ seedId, keyId })
+      return curve25519.signOpen({ signed: data, publicKey, format: 'buffer' })
     },
     signDetached: async ({ seedId, keyId, data }) => {
-      const { sign } = await getSodiumKeysFromIdentifier({ seedId, keyId })
-      return sodium.signDetached({ message: data, privateKey: sign.privateKey })
+      const { privateKey } = getPrivateHDKey({ seedId, keyId })
+      return curve25519.signDetached({ message: data, privateKey, format: 'buffer' })
     },
     verifyDetached: async ({ seedId, keyId, data, signature }) => {
-      const { sign } = await getSodiumKeysFromIdentifier({ seedId, keyId })
-      return sodium.verifyDetached({ message: data, sig: signature, publicKey: sign.publicKey })
+      const { publicKey } = getPrivateHDKey({ seedId, keyId })
+      return curve25519.verifyDetached({ message: data, signature, publicKey })
     },
     encryptSecretBox: async ({ seedId, keyId, data }) => {
       const { privateKey: sodiumSeed } = getPrivateHDKey({ seedId, keyId })
@@ -90,8 +91,5 @@ export const create = ({ getPrivateHDKey }) => {
 }
 
 export const privToPub = async (sodiumSeed) => {
-  const {
-    sign: { publicKey },
-  } = await sodium.getSodiumKeysFromSeed(sodiumSeed)
-  return Buffer.from(publicKey)
+  return curve25519.edwardsToPublic({ privateKey: sodiumSeed, format: 'buffer' })
 }

--- a/features/keychain/package.json
+++ b/features/keychain/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@exodus/basic-utils": "^3.0.1",
     "@exodus/bip32": "^3.3.0",
-    "@exodus/crypto": "^1.0.0-rc.13",
+    "@exodus/crypto": "^1.0.0-rc.16",
     "@exodus/key-identifier": "^1.3.0",
     "@exodus/key-utils": "^3.7.0",
     "@exodus/slip10": "^2.1.0",

--- a/features/keychain/package.json
+++ b/features/keychain/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@exodus/basic-utils": "^3.0.1",
     "@exodus/bip32": "^3.3.0",
-    "@exodus/crypto": "^1.0.0-rc.16",
+    "@exodus/crypto": "^1.0.0-rc.18",
     "@exodus/key-identifier": "^1.3.0",
     "@exodus/key-utils": "^3.7.0",
     "@exodus/slip10": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,13 +2357,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@exodus/crypto@npm:^1.0.0-rc.11, @exodus/crypto@npm:^1.0.0-rc.13":
-  version: 1.0.0-rc.13
-  resolution: "@exodus/crypto@npm:1.0.0-rc.13"
+"@exodus/crypto@npm:^1.0.0-rc.11, @exodus/crypto@npm:^1.0.0-rc.13, @exodus/crypto@npm:^1.0.0-rc.16":
+  version: 1.0.0-rc.16
+  resolution: "@exodus/crypto@npm:1.0.0-rc.16"
   dependencies:
+    "@noble/ed25519": ^1.7.3
     "@noble/hashes": ^1.3.3
     "@noble/secp256k1": ^1.7.1
-  checksum: 06b3e73a745ed6766471052bb5571d9bf2d3c4cbabd9c21fa2bab0f1ffba63f8b41e84660cda22991ba8d90e516114dc9515da220d4ff12e5c12e5c03bd2e6d1
+  checksum: 44d517770dd08c06a332baa86fe7a7c9ccbbefa19217f71c58646e6c43b44c5251f86b9cc45171cf607e38fd057c2f237be053c3432721704e7ab45691e4df7a
   languageName: node
   linkType: hard
 
@@ -2520,7 +2521,7 @@ __metadata:
   dependencies:
     "@exodus/basic-utils": ^3.0.1
     "@exodus/bip32": ^3.3.0
-    "@exodus/crypto": ^1.0.0-rc.13
+    "@exodus/crypto": ^1.0.0-rc.16
     "@exodus/key-identifier": ^1.3.0
     "@exodus/key-ids": ^1.0.0
     "@exodus/key-utils": ^3.7.0
@@ -3164,6 +3165,13 @@ __metadata:
   dependencies:
     eslint-scope: 5.1.1
   checksum: f2e3b2d6a6e2d9f163ca22105910c9f850dc4897af0aea3ef0a5886b63d8e1ba6505b71c99cb78a3bba24a09557d601eb21c8dede3f3213753fcfef364eb0e57
+  languageName: node
+  linkType: hard
+
+"@noble/ed25519@npm:^1.7.3":
+  version: 1.7.3
+  resolution: "@noble/ed25519@npm:1.7.3"
+  checksum: 45169927d51de513e47bbeebff3a603433c4ac7579e1b8c5034c380a0afedbe85e6959be3d69584a7a5ed6828d638f8f28879003b9bb2fb5f22d8aa2d88fd5fe
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,14 +2357,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@exodus/crypto@npm:^1.0.0-rc.11, @exodus/crypto@npm:^1.0.0-rc.13, @exodus/crypto@npm:^1.0.0-rc.16":
-  version: 1.0.0-rc.16
-  resolution: "@exodus/crypto@npm:1.0.0-rc.16"
+"@exodus/crypto@npm:^1.0.0-rc.11, @exodus/crypto@npm:^1.0.0-rc.13, @exodus/crypto@npm:^1.0.0-rc.18":
+  version: 1.0.0-rc.18
+  resolution: "@exodus/crypto@npm:1.0.0-rc.18"
   dependencies:
     "@noble/ed25519": ^1.7.3
     "@noble/hashes": ^1.3.3
     "@noble/secp256k1": ^1.7.1
-  checksum: 44d517770dd08c06a332baa86fe7a7c9ccbbefa19217f71c58646e6c43b44c5251f86b9cc45171cf607e38fd057c2f237be053c3432721704e7ab45691e4df7a
+  checksum: c913352057cf14f1dda1302d4077299288a1cefee57535018a0bdce447d3ab1d28e594c39bd4a15ee47839ffae1801d8ba593464b4ae4c907cb69da7e5d0fb6d
   languageName: node
   linkType: hard
 
@@ -2521,7 +2521,7 @@ __metadata:
   dependencies:
     "@exodus/basic-utils": ^3.0.1
     "@exodus/bip32": ^3.3.0
-    "@exodus/crypto": ^1.0.0-rc.16
+    "@exodus/crypto": ^1.0.0-rc.18
     "@exodus/key-identifier": ^1.3.0
     "@exodus/key-ids": ^1.0.0
     "@exodus/key-utils": ^3.7.0


### PR DESCRIPTION
Still uses sodium for boxes

Other methods are ported to `@exodus/crypto/curve25519`

Values (and their formats) are equivalent in-place