### PR TITLE
fix: add signSchnorr to keychain api

### DIFF
--- a/features/keychain/api/__tests__/index.test.js
+++ b/features/keychain/api/__tests__/index.test.js
@@ -221,5 +221,21 @@ describe('keychain api', () => {
         '3045022100f3aab0f6b44f62ef387050c86fb79bacabb36b254d3017d83dc801b8e72ad58602202339bf7576cb07eadd82c9ce97d5c117ceeaa3d0b990695ae9f6e7659f535fac'
       )
     })
+
+    test('signSchnorr signs binary data', async () => {
+      const data = await hash('sha256', "Batman's identity was revealed as Harvey Dent")
+      const signature = await api.secp256k1.signSchnorr({
+        seedId,
+        keyId,
+        data,
+        extraEntropy: Buffer.from(
+          '1230000000000000000000000000000000000000000000000000000000000000',
+          'hex'
+        ),
+      })
+      expect(Buffer.from(signature).toString('hex')).toBe(
+        'd8a41b022fab008d1d8bc32ce99dd16a4edae37da691047b3729d626c47d6e0850f78245656bc0edccf6002936b96fe04bb4553be5334cf425ac94ca2da33a2e'
+      )
+    })
   })
 })

--- a/features/keychain/api/index.js
+++ b/features/keychain/api/index.js
@@ -16,6 +16,7 @@ const createKeychainApi = ({ keychain }) => {
       },
       secp256k1: {
         signBuffer: keychain.secp256k1.signBuffer,
+        signSchnorr: keychain.secp256k1.signSchnorr,
       },
     },
   }


### PR DESCRIPTION
It fixes the keychain's api adding `secp256k1.signSchnorr`. If not, signing btc taproot fails with an undefiend error. [Thread](https://exodusio.slack.com/archives/C05N2GG2030/p1731346139507139) 