### PR TITLE
fix: schnorrSign return type and type and signature

### DIFF
--- a/features/keychain/api/__tests__/index.test.js
+++ b/features/keychain/api/__tests__/index.test.js
@@ -256,7 +256,7 @@ describe('keychain api', () => {
           'hex'
         ),
       })
-      expect(Buffer.from(signature).toString('hex')).toBe(
+      expect(signature.toString('hex')).toBe(
         'd8a41b022fab008d1d8bc32ce99dd16a4edae37da691047b3729d626c47d6e0850f78245656bc0edccf6002936b96fe04bb4553be5334cf425ac94ca2da33a2e'
       )
     })

--- a/features/keychain/api/index.d.ts
+++ b/features/keychain/api/index.d.ts
@@ -36,7 +36,9 @@ export interface KeychainApi {
   secp256k1: {
     signBuffer(params: { data: Buffer } & KeySource): Promise<Buffer>
     signBuffer(params: { data: Buffer; enc: 'der' } & KeySource): Promise<Buffer>
-    signSchnorr(params: { data: Buffer; extraEntropy?: Buffer } & KeySource): Promise<Buffer>
+    signSchnorr(
+      params: { data: Buffer; extraEntropy?: Buffer; tweak?: Buffer } & KeySource
+    ): Promise<Buffer>
   }
 }
 

--- a/features/keychain/api/index.d.ts
+++ b/features/keychain/api/index.d.ts
@@ -36,7 +36,7 @@ export interface KeychainApi {
   secp256k1: {
     signBuffer(params: { data: Buffer } & KeySource): Promise<Buffer>
     signBuffer(params: { data: Buffer; enc: 'der' } & KeySource): Promise<Buffer>
-    signSchnorr(params: { data: Buffer; tweak?: Buffer } & KeySource): Promise<Buffer>
+    signSchnorr(params: { data: Buffer; extraEntropy?: Buffer } & KeySource): Promise<Buffer>
   }
 }
 

--- a/features/keychain/module/__tests__/schnorr.test.js
+++ b/features/keychain/module/__tests__/schnorr.test.js
@@ -60,7 +60,7 @@ describe('Schnorr signer', () => {
       extraEntropy: Buffer.from(fixture.entropy, 'hex'),
     })
 
-    expect(Buffer.from(result).toString('hex')).toBe(fixture.sig)
+    expect(result.toString('hex')).toBe(fixture.sig)
   })
 
   it('should throw for keyType != secp256k1', async () => {

--- a/features/keychain/module/crypto/secp256k1.js
+++ b/features/keychain/module/crypto/secp256k1.js
@@ -49,7 +49,7 @@ export const create = ({ getPrivateHDKey }) => {
       )
       const hdkey = getPrivateHDKey({ seedId, keyId })
       const privateKey = tweak ? tweakPrivateKey({ hdkey, tweak }) : hdkey.privateKey
-      return Buffer.from(await secp256k1.schnorrSign({ data, privateKey, extraEntropy }))
+      return secp256k1.schnorrSign({ data, privateKey, extraEntropy, format: 'buffer' })
     },
   })
 

--- a/features/keychain/module/crypto/secp256k1.js
+++ b/features/keychain/module/crypto/secp256k1.js
@@ -49,7 +49,7 @@ export const create = ({ getPrivateHDKey }) => {
       )
       const hdkey = getPrivateHDKey({ seedId, keyId })
       const privateKey = tweak ? tweakPrivateKey({ hdkey, tweak }) : hdkey.privateKey
-      return secp256k1.schnorrSign({ data, privateKey, extraEntropy })
+      return Buffer.from(await secp256k1.schnorrSign({ data, privateKey, extraEntropy }))
     },
   })
 


### PR DESCRIPTION
This PR adds the missing schnorrSign ts type and fixes the return type to be `Buffer` rather than just `Uint8Array` for consistency