### PR TITLE
ci: update release action and only publish from protected branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,8 @@ jobs:
         run: yarn install --immutable
       - name: Build
         run: yarn build
-      - uses: ExodusMovement/lerna-release-action/publish@f7bb33dbbd7a57206eea2fcb79d7fcc2a61bcbb9
+      - uses: ExodusMovement/lerna-release-action/publish@6dc016246588346b8181638a1c093d8c8e14c7f8
         id: publish
         with:
           github-token: ${{ secrets.GH_AUTOMATION_PAT }}
+          required-branch-rulesets: 179028

--- a/.github/workflows/version-dispatch.yaml
+++ b/.github/workflows/version-dispatch.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ExodusMovement/lerna-release-action/version-dispatch@f7bb33dbbd7a57206eea2fcb79d7fcc2a61bcbb9
+      - uses: ExodusMovement/lerna-release-action/version-dispatch@6dc016246588346b8181638a1c093d8c8e14c7f8
         with:
           version-workflow-id: version.yaml
           github-token: ${{ secrets.GH_AUTOMATION_PAT }}

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Prepare
         run: yarn prepare
       - name: Version
-        uses: ExodusMovement/lerna-release-action/version@f7bb33dbbd7a57206eea2fcb79d7fcc2a61bcbb9
+        uses: ExodusMovement/lerna-release-action/version@6dc016246588346b8181638a1c093d8c8e14c7f8
         with:
           github-token: ${{ secrets.GH_AUTOMATION_PAT }}
           packages: ${{ inputs.packages }}


### PR DESCRIPTION
Update to the latest release action and refuse publishing from branches that are not protected by the default ruleset