### PR TITLE
perf: cache `getSodiumKeysFromSeed` for same seed

### DIFF
--- a/features/keychain/module/__tests__/sodium.test.js
+++ b/features/keychain/module/__tests__/sodium.test.js
@@ -4,11 +4,11 @@ import KeyIdentifier from '@exodus/key-identifier'
 import { getSeedId } from '../crypto/seed-id.js'
 import { getSodiumKeysFromSeed } from '@exodus/crypto/sodium'
 
-const sodiumKeysFromSeedMock = jest.fn(getSodiumKeysFromSeed)
+const getSodiumKeysFromSeedMock = jest.fn(getSodiumKeysFromSeed)
 
 jest.mock('@exodus/crypto/sodium', () => ({
   __esModule: true,
-  getSodiumKeysFromSeed: sodiumKeysFromSeedMock,
+  getSodiumKeysFromSeed: getSodiumKeysFromSeedMock,
 }))
 
 const { default: createKeychain } = await import('./create-keychain.js')
@@ -50,7 +50,7 @@ describe('libsodium', () => {
       keyId: BOB_KEY,
     })
 
-    expect(sodiumKeysFromSeedMock).toHaveBeenCalledOnce()
+    expect(getSodiumKeysFromSeedMock).toHaveBeenCalledOnce()
   })
 
   it('should have sign keys compatibility with SLIP10', async () => {

--- a/features/keychain/module/crypto/sodium.js
+++ b/features/keychain/module/crypto/sodium.js
@@ -1,5 +1,5 @@
 import sodium from '@exodus/sodium-crypto'
-import { mapValues } from '@exodus/basic-utils'
+import { mapValues, memoize } from '@exodus/basic-utils'
 import * as curve25519 from '@exodus/crypto/curve25519'
 import { getSodiumKeysFromSeed } from '@exodus/crypto/sodium'
 
@@ -16,13 +16,18 @@ const cloneKeypair = ({ keys, exportPrivate }) => {
   }
 }
 
+export const getMemoizedSodiumKeysFromSeed = memoize(getSodiumKeysFromSeed, (seed) =>
+  seed.toString('hex')
+)
+
 export const create = ({ getPrivateHDKey }) => {
   // Sodium encryptor caches the private key and the return value holds
   // not refences to keychain internals, allowing the seed to be safely
   // garbage collected, clearing it from memory.
+
   const getSodiumKeysFromIdentifier = async ({ seedId, keyId }) => {
     const { privateKey: sodiumSeed } = getPrivateHDKey({ seedId, keyId })
-    return getSodiumKeysFromSeed(sodiumSeed)
+    return getMemoizedSodiumKeysFromSeed(sodiumSeed)
   }
 
   const getKeysFromSeed = async ({ seedId, keyId, exportPrivate }) => {


### PR DESCRIPTION
Avoid generating the signing/box key pairs repeatedly for multiple encryptBox/decryptBox operations. 