### PR TITLE
fix: propagate all values from sodium.getKeysFromSeed via api

### DIFF
--- a/features/keychain/api/__tests__/index.test.js
+++ b/features/keychain/api/__tests__/index.test.js
@@ -234,7 +234,7 @@ describe('keychain api', () => {
     test('getKeysFromSeed returns public keys', async () => {
       const keys = await api.sodium.getKeysFromSeed({ seedId, keyId })
 
-      expect(keys.secret).toBeUndefined()
+      expect(keys.secret).toBeNull()
       expect(keys.sign.publicKey.toString('hex')).toBe(
         '5960b9980b740a241dea0d44fe304b196484eab1427ee9e7999b5eeff21cdac9'
       )

--- a/features/keychain/api/index.js
+++ b/features/keychain/api/index.js
@@ -12,8 +12,7 @@ const createKeychainApi = ({ keychain }) => {
         decryptSecretBox: keychain.sodium.decryptSecretBox,
         encryptBox: keychain.sodium.encryptBox,
         decryptBox: keychain.sodium.decryptBox,
-        getKeysFromSeed: (...args) =>
-          keychain.sodium.getKeysFromSeed(...args).then(({ box, sign }) => ({ box, sign })),
+        getKeysFromSeed: keychain.sodium.getKeysFromSeed,
       },
       ed25519: {
         signBuffer: keychain.ed25519.signBuffer,


### PR DESCRIPTION
@sparten11740 we need this for fusion when using the wallet-sdk. The keychain API needs to return the same values as the keychain module here: https://github.com/ExodusMovement/exodus-hydra/blob/e00af1ac93cb4462f5a7626da3b28a90fff916d1/sdks/headless/src/migrations/attach.js#L53