### PR TITLE
fix: import derivation-path directly instead of all key-utils

### DIFF
--- a/libraries/key-identifier/src/key-identifier.js
+++ b/libraries/key-identifier/src/key-identifier.js
@@ -1,5 +1,5 @@
 import assert from 'minimalistic-assert'
-import { DerivationPath } from '@exodus/key-utils'
+import { DerivationPath } from '@exodus/key-utils/src/derivation-path.js'
 
 const SUPPORTED_KDFS = new Set(['BIP32', 'SLIP10'])
 const SUPPORTED_KEY_TYPES = new Set(['legacy', 'nacl', 'secp256k1'])


### PR DESCRIPTION
together with https://github.com/ExodusMovement/exodus-hydra/pull/11707

allows to use KeyIdentifier in isolated processes on desktop that forbid require('crypto')